### PR TITLE
[Fix] 아이클라우드 영상 다운로드 중 이전 영상 재생 문제

### DIFF
--- a/PiPPl/Utility/LocalVideoPlayer.swift
+++ b/PiPPl/Utility/LocalVideoPlayer.swift
@@ -37,9 +37,8 @@ class LocalVideoPlayer {
         option.version = .original
         option.deliveryMode = .highQualityFormat
 
-        PHCachingImageManager().requestAVAsset(forVideo: asset, options: option) { asset, audioMix, info in
-            guard let asset else { return }
-            self.player.replaceCurrentItem(with: AVPlayerItem(asset: asset))
+        PHImageManager.default().requestPlayerItem(forVideo: asset, options: option) { playerItem, info in
+            self.player.replaceCurrentItem(with: playerItem)
         }
     }
 

--- a/PiPPl/Utility/LocalVideoPlayer.swift
+++ b/PiPPl/Utility/LocalVideoPlayer.swift
@@ -48,6 +48,7 @@ class LocalVideoPlayer {
     }
 
     func pause() {
+        self.player.replaceCurrentItem(with: nil)
         player.pause()
     }
 

--- a/PiPPl/Utility/LocalVideoPlayer.swift
+++ b/PiPPl/Utility/LocalVideoPlayer.swift
@@ -39,6 +39,7 @@ class LocalVideoPlayer {
 
         PHImageManager.default().requestPlayerItem(forVideo: asset, options: option) { playerItem, info in
             self.player.replaceCurrentItem(with: playerItem)
+            self.play()
         }
     }
 

--- a/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
@@ -17,7 +17,6 @@ struct LocalVideoPlayView: View {
         }
         .onAppear {
             LocalVideoPlayer.shared.configureVideo(asset)
-            LocalVideoPlayer.shared.play()
         }
         .onDisappear {
             LocalVideoPlayer.shared.pause()


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- iCloud에서 영상을 다운받는 동안에 이전에 재생되던 영상이 재생되다가, 다운로드 완료 후 영상이 바뀌는 버그를 수정하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- iCloud에서 영상을 다운 받는 동안 이전 영상 재생되는 문제 수정
  - 이전 영상을 멈추고 갤러리로 나오면 `AVPlayer`의 `currentItem`을 `nil`로 만들어 이전 영상을 플레이어에서 삭제함
- `LocalVideoPlayer`의 `configureVideo(_:)` 메서드 내부 구현 리팩토링
  - `PHCachingImageManager`의 `requestAVAsset` 메서드를 통해 `PHAsset`을 `AVAsset`으로 변환한 뒤, 해당 `AVAsset`으로 `AVPlayerItem`을 구성해서 `AVPlayer`에서 재생시키던 부분을 `PHImageManager`의 `requestPlayerItem` 메서드를 통해 `PHAsset`을 `AVPlayerItem`으로 직접 변환해 `AVPlayer`에서 재생시키도록 변경
  - `AVPlayer`의 `play`를 `configureVideo` 메서드 안으로 통합

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗

## Close Issues 🔒 (닫을 Issue)
Close #19.
