### PR TITLE
[Fix] LazyVGrid 성능 문제 해결

### DIFF
--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Photos
+import UIKit
 
 class LocalVideoLibraryManager: ObservableObject {
 
@@ -27,5 +28,21 @@ class LocalVideoLibraryManager: ObservableObject {
 
     func requestVideos(in collection: PHAssetCollection) -> PHFetchResult<PHAsset> {
         return PHAsset.fetchAssets(in: collection, options: PHFetchOptions())
+    }
+
+    func requestThumbnail(_ asset: PHAsset) -> UIImage {
+        let manager = PHImageManager.default()
+        let thumbnailOption = PHImageRequestOptions()
+        thumbnailOption.isSynchronous = true
+        thumbnailOption.resizeMode = .exact
+        let size = UIScreen.main.bounds.width / 3
+        var thumbnail = UIImage()
+
+        manager.requestImage(for: asset, targetSize: CGSize(width: size, height: size), contentMode: .aspectFill, options: thumbnailOption) { result, info in
+            guard let result else { return }
+            thumbnail = result
+        }
+
+        return thumbnail
     }
 }

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -9,6 +9,12 @@ import Foundation
 import Photos
 import UIKit
 
+struct Video: Identifiable {
+    let id = UUID()
+    var asset: PHAsset
+    var thumbnail: UIImage?
+}
+
 class LocalVideoLibraryManager: ObservableObject {
 
     @Published var videos = [PHAsset]()

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -17,7 +17,7 @@ struct Video: Identifiable {
 
 class LocalVideoLibraryManager: ObservableObject {
 
-    @Published var videos = [PHAsset]()
+    @Published var videos = [Video]()
 
     static let shared = LocalVideoLibraryManager()
     var status: PHAuthorizationStatus {

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -106,22 +106,6 @@ struct LocalVideoGalleryView: View {
             }
         }
     }
-
-    private func configureThumbnail(_ asset: PHAsset) -> Image {
-        let manager = PHImageManager.default()
-        var thumbnail = Image(uiImage: UIImage(ciImage: CIImage(color: .gray)))
-        let thumbnailOption = PHImageRequestOptions()
-        thumbnailOption.isSynchronous = true
-        thumbnailOption.resizeMode = .exact
-        let size = UIScreen.main.bounds.width / 3
-
-        manager.requestImage(for: asset, targetSize: CGSize(width: size, height: size), contentMode: .aspectFill, options: thumbnailOption) { result, info in
-            guard let result else { return }
-            thumbnail = Image(uiImage: result)
-        }
-
-        return thumbnail
-    }
 }
 
 #Preview {

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -43,7 +43,11 @@ struct LocalVideoGalleryView: View {
                             status = true
                             let collection = libraryManager.requestVideoAlbums()
                             let assets = libraryManager.requestVideos(in: collection.firstObject ?? PHAssetCollection())
+                                libraryManager.videos = []
                             assets.enumerateObjects { asset, _, _ in
+                                var video = Video(asset: asset)
+                                video.thumbnail = libraryManager.requestThumbnail(asset)
+                                libraryManager.videos.append(video)
                             }
                         @unknown default:
                             break
@@ -92,9 +96,14 @@ struct LocalVideoGalleryView: View {
                 status = false
             case .authorized, .limited:
                 status = true
-                let collection = libraryManager.requestVideoAlbums()
-                let assets = libraryManager.requestVideos(in: collection.firstObject ?? PHAssetCollection())
-                assets.enumerateObjects { asset, _, _ in
+                if libraryManager.videos.isEmpty {
+                    let collection = libraryManager.requestVideoAlbums()
+                    let assets = libraryManager.requestVideos(in: collection.firstObject ?? PHAssetCollection())
+                    assets.enumerateObjects { asset, _, _ in
+                        var video = Video(asset: asset)
+                        video.thumbnail = libraryManager.requestThumbnail(asset)
+                        libraryManager.videos.append(video)
+                    }
                 }
             @unknown default:
                 break

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -51,18 +51,17 @@ struct LocalVideoGalleryView: View {
                     }
                 }
             } else {
-                GeometryReader { geo in
-                    ScrollView {
-                        LazyVGrid(columns: Array(repeating: GridItem(.fixed(geo.size.width/rowItemCount), spacing: 1), count: Int(rowItemCount)), spacing: 1) {
-                            ForEach(videos, id: \.self) { video in
-                                NavigationLink {
-                                    LocalVideoPlayView(asset: video)
-                                        .toolbar(.hidden, for: .tabBar)
-                                } label: {
-                                    ZStack(alignment: .bottomTrailing) {
-                                        configureThumbnail(video)
-                                            .resizable()
-                                            .frame(height: geo.size.width/rowItemCount)
+                ScrollView {
+                    LazyVGrid(columns: Array(repeating: GridItem(.fixed(UIScreen.main.bounds.width/rowItemCount), spacing: 1), count: Int(rowItemCount)), spacing: 1) {
+                        ForEach(libraryManager.videos, id: \.id) { video in
+                            NavigationLink {
+                                LocalVideoPlayView(asset: video.asset)
+                                    .toolbar(.hidden, for: .tabBar)
+                            } label: {
+                                ZStack(alignment: .bottomTrailing) {
+                                    Image(uiImage: video.thumbnail ?? UIImage(ciImage: CIImage(color: .gray)))
+                                        .resizable()
+                                        .frame(height: UIScreen.main.bounds.width/rowItemCount)
 
                                         let duration = Int(video.duration)
                                         Text("\(duration / 60):\(String(format: "%02d", duration % 60))")

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 
 struct LocalVideoGalleryView: View {
     @State private var status = false
-    @State private var videos = [PHAsset]()
     @State private var isOldVersion: Bool = false
     private let libraryManager = LocalVideoLibraryManager.shared
     private let appVersionManager = AppVersionManager.shared
@@ -44,9 +43,7 @@ struct LocalVideoGalleryView: View {
                             status = true
                             let collection = libraryManager.requestVideoAlbums()
                             let assets = libraryManager.requestVideos(in: collection.firstObject ?? PHAssetCollection())
-                            videos = []
                             assets.enumerateObjects { asset, _, _ in
-                                videos.append(asset)
                             }
                         @unknown default:
                             break
@@ -98,9 +95,7 @@ struct LocalVideoGalleryView: View {
                 status = true
                 let collection = libraryManager.requestVideoAlbums()
                 let assets = libraryManager.requestVideos(in: collection.firstObject ?? PHAssetCollection())
-                videos = []
                 assets.enumerateObjects { asset, _, _ in
-                    videos.append(asset)
                 }
             @unknown default:
                 break

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -67,11 +67,10 @@ struct LocalVideoGalleryView: View {
                                         .resizable()
                                         .frame(height: UIScreen.main.bounds.width/rowItemCount)
 
-                                        let duration = Int(video.duration)
-                                        Text("\(duration / 60):\(String(format: "%02d", duration % 60))")
-                                            .foregroundStyle(.white)
-                                            .padding(4)
-                                    }
+                                    let duration = Int(video.asset.duration)
+                                    Text("\(duration / 60):\(String(format: "%02d", duration % 60))")
+                                        .foregroundStyle(.white)
+                                        .padding(4)
                                 }
                             }
                         }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- UIKit의 CollectionView로 작성한 코드를 SwiftUI의 LazyVGrid로 변경하면서 생긴 성능 문제를 해결하기 위함

## Cause of Problem 🐞 (문제 발생 원인)
- 셀 뷰의 복잡성 문제
  - 각 셀에 많은 `View`가 중첩되며, `GeometryReader`와 `onAppear`, 이미지 로딩 등 무거운 작업이 함께 있어 뷰 렌더링이 느려짐
- 셀 개수가 많음
  - `LazyVGrid`가 `lazy`하게 동작하긴 하지만 내부적으로 `ForEach`로 뷰를 생성하는 방식이라 아주 많은 셀을 렌더링할 때는 셀을 `reuse`하는 `UIKit`의 `CollectionView`보다 비효율적임
- 스크롤 시 렌더링 최적화 부족
  - `SwiftUI`는 `UIKit`만큼 재사용이 정교하지 않아, 스크롤 중 뷰를 계속 생성/소멸하면서 렌더링 부하가 생김
- `configureThumbnail` 메서드를 통한 썸네일 매번 재요청
  - 이미지 캐싱 방식이 아닌 매번 썸네일을 새로 생성하기 때문에 병목 발생

## Solution 🛠️ (해결 방법)
- 복잡성 해결
  - `GeometryReader`를 삭제
  - `onAppear`에서 매번 새로 videos 배열을 새로 구성하는 것을 배열이 비었을 때만 새로 구성하도록 변경
- 썸네일 한 번만 요청하도록 변경
  - `configureThumbnail` 메서드를 통해 매번 썸네일을 새로 요청하지 않고, `requestThumbnail` 메서드를 통해 배열이 비어있을 때만 썸네일을 새로 요청하여 배열에 저장하는 방식으로 이미지 캐싱을 해 병목 해결

## Key Changes 🔥 (주요 구현/변경 사항)
- `GeometryReader` 삭제
- `configureThumbnail` 메서드 삭제 및 `reqeustThumbnail` 메서드 추가
  - 매번 썸네일을 새로 요청하지 않고, 배열이 비어있을 때만 썸네일을 요청한 뒤 배열에 저장된 이미지 사용하도록 변경

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗

## Close Issues 🔒 (닫을 Issue)
Close #22.
