### PR TITLE
[Feat] 저장된 영상이 없을 때 대응

### DIFF
--- a/PiPPl.xcodeproj/project.pbxproj
+++ b/PiPPl.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.immeenu.PiPPl;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -455,7 +455,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.0.1;
+				MARKETING_VERSION = 2.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.immeenu.PiPPl;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/PiPPl/Resource/AppText.swift
+++ b/PiPPl/Resource/AppText.swift
@@ -20,6 +20,7 @@ enum AppText {
     // MARK: - Local Video View Text
 
     static let photoGalleryAccessPermissionButtonText = String(localized: "PhotoGalleryAccessPermissionText")
+    static let photoGalleryNoVideoButtonText = String(localized: "PhotoGalleryNoVideoText")
 
     // MARK: - Network Video View Text
 

--- a/PiPPl/Resource/Localizable.xcstrings
+++ b/PiPPl/Resource/Localizable.xcstrings
@@ -463,6 +463,22 @@
         }
       }
     },
+    "PhotoGalleryNoVideoText" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There are no videos saved on your device.\nPlease save the videos in the Photos app and then tap here to try again."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기기에 저장된 영상이 없습니다.\n사진 앱에 영상을 저장한 뒤, 여기를 눌러 다시 시도해 주십시오."
+          }
+        }
+      }
+    },
     "SearchFieldPlaceholder" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -47,6 +47,10 @@ struct LocalVideoGalleryView: View {
                         }
                     }
                 }
+            } else if libraryManager.videos.isEmpty {
+                Button(AppText.photoGalleryNoVideoButtonText) {
+                    libraryManager.configureGallery()
+                }
             } else {
                 ScrollView {
                     LazyVGrid(columns: Array(repeating: GridItem(.fixed(UIScreen.main.bounds.width/rowItemCount), spacing: 1), count: Int(rowItemCount)), spacing: 1) {


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 기기에 저장된 영상이 없을 때 영상이 없음을 알리는 버튼을 추가하여 사용자에게 혼란을 줄이기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 기기에 저장된 영상이 없을 때, 영상이 없음을 알려주는 버튼 추가
- 영상 저장 후 버튼을 누르면 화면 갱신하는 기능 추가
- 영상 없음을 알리는 버튼에 보여줄 `photoGalleryNoVideoButtonText` 추가
- `photoGalleryNoVideoButtonText`에 대한 지원 언어별 문구 추가

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗

## Close Issues 🔒 (닫을 Issue)
Close #28.
