### PR TITLE
[Fix] iPad에서 네트워크 비디오 주소창 안보이는 문제 수정

### DIFF
--- a/PiPPl.xcodeproj/project.pbxproj
+++ b/PiPPl.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.immeenu.PiPPl;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -455,7 +455,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.immeenu.PiPPl;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/PiPPl/View/ContentView.swift
+++ b/PiPPl/View/ContentView.swift
@@ -33,7 +33,10 @@ struct ContentView: View {
             NavigationSplitView {
                 List {
                     NavigationLink {
-                        localVideoGalleryView
+                        NavigationStack {
+                            localVideoGalleryView
+                                .navigationTitle(AppText.localVideo)
+                        }
                     } label: {
                         Label(AppText.localVideo, systemImage: "play.square")
                     }
@@ -53,7 +56,10 @@ struct ContentView: View {
                 }
                 .listStyle(.plain)
             } detail: {
-                localVideoGalleryView
+                NavigationStack {
+                    localVideoGalleryView
+                        .navigationTitle(AppText.localVideo)
+                }
             }
         }
     }

--- a/PiPPl/View/ContentView.swift
+++ b/PiPPl/View/ContentView.swift
@@ -25,6 +25,7 @@ struct ContentView: View {
                     .tabItem { Label(AppText.networkVideo, systemImage: "globe") }
                 NavigationStack {
                     appInfoView
+                        .navigationTitle(AppText.appInfo)
                 }
                 .tabItem { Label(AppText.appInfo, systemImage: "info.circle") }
             }
@@ -42,7 +43,10 @@ struct ContentView: View {
                         Label(AppText.networkVideo, systemImage: "globe")
                     }
                     NavigationLink {
-                        appInfoView
+                        NavigationStack {
+                            appInfoView
+                                .navigationTitle(AppText.appInfo)
+                        }
                     } label: {
                         Label(AppText.appInfo, systemImage: "info.circle")
                     }

--- a/PiPPl/View/NetworkVideo/NetworkPlayerView.swift
+++ b/PiPPl/View/NetworkVideo/NetworkPlayerView.swift
@@ -16,11 +16,7 @@ struct NetworkPlayerView: View {
 
 struct WebView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
-        if UIDevice.current.systemName == "iOS" {
-            return UINavigationController(rootViewController: NetworkPlayerViewController())
-        }
-
-        return NetworkPlayerViewController()
+        return UINavigationController(rootViewController: NetworkPlayerViewController())
     }
 
     func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}

--- a/PiPPl/View/NetworkVideo/NetworkPlayerViewController.swift
+++ b/PiPPl/View/NetworkVideo/NetworkPlayerViewController.swift
@@ -10,6 +10,10 @@ import WebKit
 
 class NetworkPlayerViewController: UIViewController {
 
+    // MARK: - Proeprties
+
+    private let appVersionManager = AppVersionManager.shared
+
     // MARK: - View
 
     private var webView: WKWebView!
@@ -35,14 +39,9 @@ class NetworkPlayerViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         Task {
-            switch await AppVersionManager.shared.checkNewUpdate() {
+            switch await appVersionManager.checkNewUpdate() {
             case true:
-                guard let filePath = Bundle.main.path(forResource: "Properties", ofType: "plist"),
-                      let property = NSDictionary(contentsOfFile: filePath),
-                      let iTunesID = property["iTunesID"] as? String
-                else { return }
-
-                let appStoreOpenURL = "itms-apps://itunes.apple.com/app/apple-store/\(iTunesID)"
+                let appStoreOpenURL = "itms-apps://itunes.apple.com/app/apple-store/\(appVersionManager.iTunesID)"
                 let alert = UIAlertController(title: AppText.oldVersionAlertTitle, message: AppText.oldVersionAlertBody, preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: AppText.oldVersionAlertAction, style: .default, handler: { action in
                     guard let url = URL(string: appStoreOpenURL) else { return }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- iPad에서 네트워크 비디오 주소창 안보이는 문제를 수정하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- iPad에서 네트워크 비디오 주소창 안보이는 문제 수정
- iPad에서 로컬 비디오 네비게이션이 생기지 않는 문제 수정
- 앱 정보에 타이틀 추가

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗

## Close Issues 🔒 (닫을 Issue)
Close #30.
