### PR TITLE
[Fix] 네트워크 비디오에서 다른 뷰로 넘어가도 영상 멈추지 않는 문제 해결

### DIFF
--- a/PiPPl.xcodeproj/project.pbxproj
+++ b/PiPPl.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.1;
+				MARKETING_VERSION = 2.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.immeenu.PiPPl;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -455,7 +455,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.1;
+				MARKETING_VERSION = 2.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.immeenu.PiPPl;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/PiPPl/View/NetworkVideo/NetworkPlayerView.swift
+++ b/PiPPl/View/NetworkVideo/NetworkPlayerView.swift
@@ -9,17 +9,28 @@ import SwiftUI
 import WebKit
 
 struct NetworkPlayerView: View {
+    let webView = WebView()
+
     var body: some View {
-        WebView()
+        webView
+            .onDisappear {
+                webView.pauseVideo()
+            }
     }
 }
 
 struct WebView: UIViewControllerRepresentable {
+    let networkPlayerView = NetworkPlayerViewController()
+
     func makeUIViewController(context: Context) -> UIViewController {
-        return UINavigationController(rootViewController: NetworkPlayerViewController())
+        return UINavigationController(rootViewController: networkPlayerView)
     }
 
     func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
+
+    func pauseVideo() {
+        networkPlayerView.pauseVideo()
+    }
 }
 
 #Preview {

--- a/PiPPl/View/NetworkVideo/NetworkPlayerViewController.swift
+++ b/PiPPl/View/NetworkVideo/NetworkPlayerViewController.swift
@@ -260,6 +260,10 @@ class NetworkPlayerViewController: UIViewController {
         webView.load(request)
     }
 
+    func pauseVideo() {
+        webView.load(URLRequest(url: URL(string: "https://www.google.com/")!))
+    }
+
 }
 
 extension NetworkPlayerViewController: UITextFieldDelegate {


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 네트워크 비디오에서 다른 뷰로 넘어가도 영상이 멈추지 않는 문제를 해결하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 네트워크 비디오에서 다른 뷰로 넘어갈 때, 비디오를 멈추는 기능 추가

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗

## Close Issues 🔒 (닫을 Issue)
Close #32.
