### PR TITLE
[Fix] 권한 허용 후 바로 영상 보여주지 않고 비디오 없음 화면 보여주는 문제 수정

### DIFF
--- a/PiPPl.xcodeproj/project.pbxproj
+++ b/PiPPl.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.2;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.immeenu.PiPPl;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -455,7 +455,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.2;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.immeenu.PiPPl;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/PiPPl/Resource/AppText.swift
+++ b/PiPPl/Resource/AppText.swift
@@ -21,6 +21,7 @@ enum AppText {
 
     static let photoGalleryAccessPermissionButtonText = String(localized: "PhotoGalleryAccessPermissionText")
     static let photoGalleryNoVideoButtonText = String(localized: "PhotoGalleryNoVideoText")
+    static let photoGalleryLoadText = String(localized: "PhotoGalleryLoadText")
 
     // MARK: - Network Video View Text
 

--- a/PiPPl/Resource/Localizable.xcstrings
+++ b/PiPPl/Resource/Localizable.xcstrings
@@ -11,6 +11,9 @@
         }
       }
     },
+    "%lld%%" : {
+
+    },
     "AppInfo" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -459,6 +462,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "사진 앨범 접근 권한을 허용해주세요"
+          }
+        }
+      }
+    },
+    "PhotoGalleryLoadText" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading videos stored on your device."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기기에 저장된 영상을 불러오는 중 입니다."
           }
         }
       }

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -40,8 +40,8 @@ struct LocalVideoGalleryView: View {
                         case .notDetermined, .restricted, .denied:
                             status = false
                         case .authorized, .limited:
-                            status = true
                             libraryManager.configureGallery()
+                            status = true
                         @unknown default:
                             break
                         }

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -11,7 +11,8 @@ import SwiftUI
 struct LocalVideoGalleryView: View {
     @State private var status = false
     @State private var isOldVersion: Bool = false
-    private let libraryManager = LocalVideoLibraryManager.shared
+    @StateObject private var libraryManager = LocalVideoLibraryManager.shared
+    @Environment(\.colorScheme) private var colorScheme
     private let appVersionManager = AppVersionManager.shared
     var rowItemCount: Double {
         if UIDevice.current.systemName == "iOS" {
@@ -32,7 +33,7 @@ struct LocalVideoGalleryView: View {
     }
 
     var body: some View {
-        VStack {
+        ZStack {
             if !status {
                 Button(AppText.photoGalleryAccessPermissionButtonText) {
                     PHPhotoLibrary.requestAuthorization(for: .readWrite) { stat in
@@ -71,6 +72,24 @@ struct LocalVideoGalleryView: View {
                                 }
                             }
                         }
+                    }
+                }
+            }
+
+            if libraryManager.isLoading {
+                VStack {
+                    ZStack {
+                        Color(colorScheme == .light ? #colorLiteral(red: 0.2196078431, green: 0.2196078431, blue: 0.2196078431, alpha: 1) : #colorLiteral(red: 0.5490196078, green: 0.5490196078, blue: 0.5490196078, alpha: 1))
+                        Color(colorScheme == .light ? #colorLiteral(red: 0.7019607843, green: 0.7019607843, blue: 0.7019607843, alpha: 0.82) : #colorLiteral(red: 0.1450980392, green: 0.1450980392, blue: 0.1450980392, alpha: 0.82))
+                        VStack {
+                            HStack {
+                                Text(AppText.photoGalleryLoadText)
+                                Spacer()
+                                Text("\(Int(libraryManager.videoLoadingProgress * 100))%")
+                            }
+                            ProgressView(value: libraryManager.videoLoadingProgress)
+                        }
+                        .frame(width: UIScreen.main.bounds.width / 3)
                     }
                 }
             }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 사진 앱 접근 권한 허용 후, 바로 영상 목록을 보여주지 않고, 영상을 불러왔음에도 영상 없음 화면을 보여주는 문제를 수정하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 사진 앱 접근 권한 허용 후, 바로 영상 목록을 보여주지 않고 영상 불러왔음에도 영상 없음 화면 보여주는 문제 수정
  - status 변수 설정 위치 변경
- 권한 허용 후 기기에서 영상을 불러올 때, 사용자가 앱이 멈췄다고 생각하지 않도록 영상 불러오기 진행률 표시 기능 추가

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗

## Close Issues 🔒 (닫을 Issue)
- Close #36.
- Close #38.
