### PR TITLE
[Fix] 공지사항 중복 버그 수정

### DIFF
--- a/PiPPl/Utility/NetworkManager.swift
+++ b/PiPPl/Utility/NetworkManager.swift
@@ -11,8 +11,6 @@ final class NetworkManager {
 
     static let shared = NetworkManager()
 
-    var notices = [Notice]()
-
     private init() {}
 
     func requestNoticeData(completion: @escaping ([Notice]) -> Void) {

--- a/PiPPl/View/AppInfo/NoticeView.swift
+++ b/PiPPl/View/AppInfo/NoticeView.swift
@@ -19,7 +19,7 @@ struct NoticeView: View {
     @State private var item = [NoticeItem]()
 
     var body: some View {
-        List(item, children: \.content) { item in
+        List(item.reversed(), children: \.content) { item in
             VStack(alignment: .leading) {
                 if item.date != nil {
                     Text(item.date!)
@@ -41,8 +41,6 @@ struct NoticeView: View {
                     item.append(NoticeItem(title: notice.title, date: notice.createDate, content: [NoticeItem(title: notice.content)]))
                 }
             }
-
-            item.reverse()
         }
     }
 }

--- a/PiPPl/View/AppInfo/NoticeView.swift
+++ b/PiPPl/View/AppInfo/NoticeView.swift
@@ -34,6 +34,8 @@ struct NoticeView: View {
         .listStyle(.grouped)
         .navigationTitle(AppText.notice)
         .onAppear {
+            item = []
+
             networkManager.requestNoticeData { notices in
                 for notice in notices {
                     item.append(NoticeItem(title: notice.title, date: notice.createDate, content: [NoticeItem(title: notice.content)]))


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 공지사항이 중복되는 버그를 해결하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 공지사항 중복 버그 수정
  - onAppear시 item 배열을 비우도록 하는 코드 추가
- 사용되지 않는 코드 삭제
- item reverse 코드 수정
  - item을 직접 reverse하는게 아니라 reversed된 item 배열을 리스트에 보여주도록 변경

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗

## Close Issues 🔒 (닫을 Issue)
Close #35.
