### PR TITLE
[Feature] 사진 앱에 새로운 영상이 추가되었을 때, 앱의 갤러리에도 추가 외 기타 개선

### DIFF
--- a/PiPPl/Resource/AppText.swift
+++ b/PiPPl/Resource/AppText.swift
@@ -17,6 +17,10 @@ enum AppText {
     static let networkVideo = String(localized: "NetworkVideo")
     static let appInfo = String(localized: "AppInfo")
 
+    // MARK: - Content View Text
+
+    static let notSupportDevice = String(localized: "NotSupportDevice")
+
     // MARK: - Local Video View Text
 
     static let photoGalleryAccessPermissionButtonText = String(localized: "PhotoGalleryAccessPermissionText")

--- a/PiPPl/Resource/Localizable.xcstrings
+++ b/PiPPl/Resource/Localizable.xcstrings
@@ -398,6 +398,22 @@
         }
       }
     },
+    "NotSupportDevice" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This app is only supported on iPhone and iPad.\nPlease check your device model."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "해당 앱은 iPhone과 iPad에서만 지원합니다.\n기기의 기종을 확인해주세요."
+          }
+        }
+      }
+    },
     "OldVersionAlertAction" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -43,22 +43,27 @@ class LocalVideoLibraryManager: NSObject, ObservableObject, PHPhotoLibraryChange
         guard let collection = requestVideoAlbums().firstObject else { return }
         let assets = requestVideos(in: collection)
         var newVideos = [Video]()
+        self.assetFetchResult = assets
+        updateVideos(assets)
+    }
+
+    func updateVideos(_ assets: PHFetchResult<PHAsset>) {
+        var updatedVideos = [Video]()
         var loadedCount = 0
-        DispatchQueue.main.async {
-            self.isLoading = true
-        }
+        self.isLoading = true
 
         assets.enumerateObjects { asset, _, _ in
             let thumbnail = self.requestThumbnail(asset)
-            newVideos.append(.init(asset: asset, thumbnail: thumbnail))
+            updatedVideos.append(.init(asset: asset, thumbnail: thumbnail))
             loadedCount += 1
+
             DispatchQueue.main.async {
                 self.videoLoadingProgress = Double(loadedCount) / Double(assets.count)
             }
         }
 
         DispatchQueue.main.async {
-            self.videos = newVideos
+            self.videos = updatedVideos
             self.isLoading = false
         }
     }

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -21,6 +21,7 @@ class LocalVideoLibraryManager: ObservableObject {
     @Published var videos = [Video]()
     @Published var videoLoadingProgress: Double = 0.0
     @Published var isLoading = false
+    private var assetFetchResult: PHFetchResult<PHAsset>?
 
     static let shared = LocalVideoLibraryManager()
     var status: PHAuthorizationStatus {

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -30,7 +30,14 @@ class LocalVideoLibraryManager: NSObject, ObservableObject, PHPhotoLibraryChange
         }
     }
 
-    private init() {}
+    override private init() {
+        super.init()
+        PHPhotoLibrary.shared().register(self)
+    }
+
+    deinit {
+        PHPhotoLibrary.shared().unregisterChangeObserver(self)
+    }
 
     func configureGallery() {
         guard let collection = requestVideoAlbums().firstObject else { return }
@@ -78,5 +85,8 @@ class LocalVideoLibraryManager: NSObject, ObservableObject, PHPhotoLibraryChange
         }
 
         return thumbnail
+    }
+
+    func photoLibraryDidChange(_ changeInstance: PHChange) {
     }
 }

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -16,7 +16,7 @@ struct Video: Identifiable {
     var thumbnail: UIImage?
 }
 
-class LocalVideoLibraryManager: ObservableObject {
+class LocalVideoLibraryManager: NSObject, ObservableObject, PHPhotoLibraryChangeObserver {
 
     @Published var videos = [Video]()
     @Published var videoLoadingProgress: Double = 0.0

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -42,9 +42,16 @@ class LocalVideoLibraryManager: NSObject, ObservableObject, PHPhotoLibraryChange
     func configureGallery() {
         guard let collection = requestVideoAlbums().firstObject else { return }
         let assets = requestVideos(in: collection)
-        var newVideos = [Video]()
         self.assetFetchResult = assets
         updateVideos(assets)
+    }
+
+    func requestVideoAlbums() -> PHFetchResult<PHAssetCollection> {
+        return PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumVideos, options: PHFetchOptions())
+    }
+
+    func requestVideos(in collection: PHAssetCollection) -> PHFetchResult<PHAsset> {
+        return PHAsset.fetchAssets(in: collection, options: PHFetchOptions())
     }
 
     func updateVideos(_ assets: PHFetchResult<PHAsset>) {
@@ -66,14 +73,6 @@ class LocalVideoLibraryManager: NSObject, ObservableObject, PHPhotoLibraryChange
             self.videos = updatedVideos
             self.isLoading = false
         }
-    }
-
-    func requestVideoAlbums() -> PHFetchResult<PHAssetCollection> {
-        return PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumVideos, options: PHFetchOptions())
-    }
-
-    func requestVideos(in collection: PHAssetCollection) -> PHFetchResult<PHAsset> {
-        return PHAsset.fetchAssets(in: collection, options: PHFetchOptions())
     }
 
     func requestThumbnail(_ asset: PHAsset) -> UIImage {

--- a/PiPPl/View/ContentView.swift
+++ b/PiPPl/View/ContentView.swift
@@ -61,6 +61,8 @@ struct ContentView: View {
                         .navigationTitle(AppText.localVideo)
                 }
             }
+        } else {
+            Text(AppText.notSupportDevice)
         }
     }
 }

--- a/PiPPl/View/ContentView.swift
+++ b/PiPPl/View/ContentView.swift
@@ -13,7 +13,7 @@ struct ContentView: View {
     let appInfoView = AppInfoView()
 
     var body: some View {
-        if UIDevice.current.systemName == "iOS" {
+        if UIDevice.current.userInterfaceIdiom == .phone {
             TabView {
                 NavigationStack {
                     localVideoGalleryView
@@ -29,7 +29,7 @@ struct ContentView: View {
                 }
                 .tabItem { Label(AppText.appInfo, systemImage: "info.circle") }
             }
-        } else {
+        } else if UIDevice.current.userInterfaceIdiom == .pad {
             NavigationSplitView {
                 List {
                     NavigationLink {

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -15,13 +15,13 @@ struct LocalVideoGalleryView: View {
     @Environment(\.colorScheme) private var colorScheme
     private let appVersionManager = AppVersionManager.shared
     var rowItemCount: Double {
-        if UIDevice.current.systemName == "iOS" {
+        if UIDevice.current.userInterfaceIdiom == .phone {
             if UIDevice.current.orientation == .portrait {
                 return 3
             } else {
                 return 5
             }
-        } else if UIDevice.current.systemName == "iPadOS" {
+        } else if UIDevice.current.userInterfaceIdiom == .pad {
             if UIDevice.current.orientation == .portrait {
                 return 5
             } else {


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 사진 앱에 새로운 영상이 추가되었을 때, 앱에 바로 반영하기 위함
- 앱의 기기별 분기를 개선하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 사진 앱에 새로운 영상 추가되었을 때, 이를 감지하고 앱에 바로 반영하는 기능 추가
  - `PHPhotoLibraryChangeObserver` 추가
- 앱의 기기 구분 방식 개선
  - `UIDevice.current`의 `systemName`을 `userInterfaceIdiom` 방식으로 변경 (휴먼 에러 줄이고, 더 확실한 기기 구분을 위함)
  - 지원하지 않는 기기 분기 추가

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗
- [Apple Developer Documentation/Photos/PHPhotoLibraryObserver](https://developer.apple.com/documentation/photos/phphotolibrarychangeobserver)
- [Apple Developer Documentation/UIKit/UIDevice/userInterfaceIdiom](https://developer.apple.com/documentation/uikit/uidevice/userinterfaceidiom)

## Close Issues 🔒 (닫을 Issue)
- Close #24.
- Close #41.
