### PR TITLE
[Feat] 영상 불러오는 동안 진행률 표시 기능 추가

### DIFF
--- a/PiPPl/Resource/AppText.swift
+++ b/PiPPl/Resource/AppText.swift
@@ -25,7 +25,7 @@ enum AppText {
 
     static let photoGalleryAccessPermissionButtonText = String(localized: "PhotoGalleryAccessPermissionText")
     static let photoGalleryNoVideoButtonText = String(localized: "PhotoGalleryNoVideoText")
-    static let photoGalleryLoadText = String(localized: "PhotoGalleryLoadText")
+    static let videoLoadText = String(localized: "VideoLoadText")
 
     // MARK: - Network Video View Text
 

--- a/PiPPl/Resource/Localizable.xcstrings
+++ b/PiPPl/Resource/Localizable.xcstrings
@@ -482,22 +482,6 @@
         }
       }
     },
-    "PhotoGalleryLoadText" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading videos stored on your device."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기기에 저장된 영상을 불러오는 중 입니다."
-          }
-        }
-      }
-    },
     "PhotoGalleryNoVideoText" : {
       "localizations" : {
         "en" : {
@@ -527,6 +511,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "여기에 주소를 입력해주세요."
+          }
+        }
+      }
+    },
+    "VideoLoadText" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The video is loading."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "영상을 불러오는 중 입니다."
           }
         }
       }

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -89,7 +89,8 @@ struct LocalVideoGalleryView: View {
                             }
                             ProgressView(value: libraryManager.videoLoadingProgress)
                         }
-                        .frame(width: UIScreen.main.bounds.width / 3)
+                        .padding()
+                        .frame(width: UIDevice.current.userInterfaceIdiom == .phone ? UIScreen.main.bounds.width : UIScreen.main.bounds.width / 5 * 3)
                     }
                 }
             }

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -83,7 +83,7 @@ struct LocalVideoGalleryView: View {
                         Color(colorScheme == .light ? #colorLiteral(red: 0.7019607843, green: 0.7019607843, blue: 0.7019607843, alpha: 0.82) : #colorLiteral(red: 0.1450980392, green: 0.1450980392, blue: 0.1450980392, alpha: 0.82))
                         VStack {
                             HStack {
-                                Text(AppText.photoGalleryLoadText)
+                                Text(AppText.videoLoadText)
                                 Spacer()
                                 Text("\(Int(libraryManager.videoLoadingProgress * 100))%")
                             }

--- a/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
@@ -12,8 +12,8 @@ import SwiftUI
 struct LocalVideoPlayView: View {
     var asset: PHAsset
     var body: some View {
-        VStack {
             LocalPlayerView(player: LocalVideoPlayer.shared.player)
+        ZStack {
         }
         .onAppear {
             LocalVideoPlayer.shared.configureVideo(asset)

--- a/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
@@ -18,6 +18,20 @@ struct LocalVideoPlayView: View {
         ZStack {
             LocalPlayerView(player: localVideoPlayer.player)
 
+            if localVideoPlayer.isVideoLoading {
+                Color(colorScheme == .light ? #colorLiteral(red: 0.2196078431, green: 0.2196078431, blue: 0.2196078431, alpha: 1) : #colorLiteral(red: 0.5490196078, green: 0.5490196078, blue: 0.5490196078, alpha: 1))
+                Color(colorScheme == .light ? #colorLiteral(red: 0.7019607843, green: 0.7019607843, blue: 0.7019607843, alpha: 0.82) : #colorLiteral(red: 0.1450980392, green: 0.1450980392, blue: 0.1450980392, alpha: 0.82))
+                VStack {
+                    HStack {
+                        Text(AppText.videoLoadText)
+                        Spacer()
+                        Text("\(Int(localVideoPlayer.videoLoadProgress * 100))%")
+                    }
+                    ProgressView(value: localVideoPlayer.videoLoadProgress)
+                }
+                .padding()
+                .frame(width: UIDevice.current.userInterfaceIdiom == .phone ? UIScreen.main.bounds.width : UIScreen.main.bounds.width / 5 * 3)
+            }
         }
         .onAppear {
             localVideoPlayer.configureVideo(asset)

--- a/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct LocalVideoPlayView: View {
     @StateObject private var localVideoPlayer = LocalVideoPlayer.shared
+    @Environment(\.colorScheme) var colorScheme
     var asset: PHAsset
 
     var body: some View {

--- a/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
@@ -10,16 +10,19 @@ import Photos
 import SwiftUI
 
 struct LocalVideoPlayView: View {
+    @StateObject private var localVideoPlayer = LocalVideoPlayer.shared
     var asset: PHAsset
+
     var body: some View {
-            LocalPlayerView(player: LocalVideoPlayer.shared.player)
         ZStack {
+            LocalPlayerView(player: localVideoPlayer.player)
+
         }
         .onAppear {
-            LocalVideoPlayer.shared.configureVideo(asset)
+            localVideoPlayer.configureVideo(asset)
         }
         .onDisappear {
-            LocalVideoPlayer.shared.pause()
+            localVideoPlayer.pause()
         }
     }
 }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 영상을 불러오는 동안 진행률을 보여줘 유저가 앱이 멈췄다고 오해하지 않게 하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- iCloud에 저장된 영상을 불러오거나, 영상을 재생하기 위해 준비하는 동안 진행률 보여주는 기능 추가
- 앱 전체에서 사용되는 진행률 표시 모달 사이즈 변경(iPhone용 사이즈 추가 및 iPad용 사이즈 변경)
- 진행률과 함께 표시되는 영상 로딩 텍스트 변경 및 통합

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗

## Close Issues 🔒 (닫을 Issue)
Close #23.
