### PR TITLE
[Chore] 업데이트 알림 주기 및 방식 변경

### DIFF
--- a/PiPPl.xcodeproj/project.pbxproj
+++ b/PiPPl.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		26DA7D512BB5D3A3002AF316 /* AppText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DA7D502BB5D3A3002AF316 /* AppText.swift */; };
 		26DA7D532BB5DD77002AF316 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 26DA7D522BB5DD77002AF316 /* InfoPlist.xcstrings */; };
 		26E63A642DC6571E000D2C53 /* UpdateState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E63A632DC65719000D2C53 /* UpdateState.swift */; };
+		26E63A6A2DC939B4000D2C53 /* VersionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E63A692DC939B1000D2C53 /* VersionModel.swift */; };
 		26E801D12DB5193100CE20BB /* LocalPlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E801D02DB5192900CE20BB /* LocalPlayerViewController.swift */; };
 		26E801D92DB9190500CE20BB /* CustomerServiceMailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E801D82DB9190500CE20BB /* CustomerServiceMailView.swift */; };
 		26EB7EE32B56AA1300282354 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26EB7EE22B56AA1300282354 /* Assets.xcassets */; };
@@ -45,6 +46,7 @@
 		26DA7D502BB5D3A3002AF316 /* AppText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppText.swift; sourceTree = "<group>"; };
 		26DA7D522BB5DD77002AF316 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		26E63A632DC65719000D2C53 /* UpdateState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateState.swift; sourceTree = "<group>"; };
+		26E63A692DC939B1000D2C53 /* VersionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionModel.swift; sourceTree = "<group>"; };
 		26E801D02DB5192900CE20BB /* LocalPlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPlayerViewController.swift; sourceTree = "<group>"; };
 		26E801D82DB9190500CE20BB /* CustomerServiceMailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerServiceMailView.swift; sourceTree = "<group>"; };
 		26EB7ED62B56AA1000282354 /* PiPPl.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PiPPl.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -115,6 +117,7 @@
 		26B742AB2BA7368D00823338 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				26E63A692DC939B1000D2C53 /* VersionModel.swift */,
 				26E63A632DC65719000D2C53 /* UpdateState.swift */,
 				26B742AC2BA736A800823338 /* NoticeModel.swift */,
 			);
@@ -255,6 +258,7 @@
 				26EBB1C62BDFE8B700C83CA2 /* ContentView.swift in Sources */,
 				2649A4B12BFF900A007FCC55 /* AppInfoView.swift in Sources */,
 				26E801D92DB9190500CE20BB /* CustomerServiceMailView.swift in Sources */,
+				26E63A6A2DC939B4000D2C53 /* VersionModel.swift in Sources */,
 				26B742AD2BA736A800823338 /* NoticeModel.swift in Sources */,
 				26EB7EF02B56AB8100282354 /* NetworkPlayerViewController.swift in Sources */,
 				2683F5512B583E3C00C1CEEB /* LocalVideoLibraryManager.swift in Sources */,

--- a/PiPPl.xcodeproj/project.pbxproj
+++ b/PiPPl.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		26DA7D4C2BB5D059002AF316 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 26DA7D4B2BB5D059002AF316 /* Localizable.xcstrings */; };
 		26DA7D512BB5D3A3002AF316 /* AppText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DA7D502BB5D3A3002AF316 /* AppText.swift */; };
 		26DA7D532BB5DD77002AF316 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 26DA7D522BB5DD77002AF316 /* InfoPlist.xcstrings */; };
+		26E63A642DC6571E000D2C53 /* UpdateState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E63A632DC65719000D2C53 /* UpdateState.swift */; };
 		26E801D12DB5193100CE20BB /* LocalPlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E801D02DB5192900CE20BB /* LocalPlayerViewController.swift */; };
 		26E801D92DB9190500CE20BB /* CustomerServiceMailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E801D82DB9190500CE20BB /* CustomerServiceMailView.swift */; };
 		26EB7EE32B56AA1300282354 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26EB7EE22B56AA1300282354 /* Assets.xcassets */; };
@@ -43,6 +44,7 @@
 		26DA7D4B2BB5D059002AF316 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		26DA7D502BB5D3A3002AF316 /* AppText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppText.swift; sourceTree = "<group>"; };
 		26DA7D522BB5DD77002AF316 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+		26E63A632DC65719000D2C53 /* UpdateState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateState.swift; sourceTree = "<group>"; };
 		26E801D02DB5192900CE20BB /* LocalPlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPlayerViewController.swift; sourceTree = "<group>"; };
 		26E801D82DB9190500CE20BB /* CustomerServiceMailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerServiceMailView.swift; sourceTree = "<group>"; };
 		26EB7ED62B56AA1000282354 /* PiPPl.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PiPPl.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -113,6 +115,7 @@
 		26B742AB2BA7368D00823338 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				26E63A632DC65719000D2C53 /* UpdateState.swift */,
 				26B742AC2BA736A800823338 /* NoticeModel.swift */,
 			);
 			path = Model;
@@ -256,6 +259,7 @@
 				26EB7EF02B56AB8100282354 /* NetworkPlayerViewController.swift in Sources */,
 				2683F5512B583E3C00C1CEEB /* LocalVideoLibraryManager.swift in Sources */,
 				263F037F2B598DFB00EAC60E /* LocalVideoPlayer.swift in Sources */,
+				26E63A642DC6571E000D2C53 /* UpdateState.swift in Sources */,
 				26EBB1C82BDFF0EB00C83CA2 /* LocalVideoGalleryView.swift in Sources */,
 				26EBB1962BC728B600C83CA2 /* AppVersionManager.swift in Sources */,
 				2649A4AF2BFF8D2B007FCC55 /* NetworkPlayerView.swift in Sources */,

--- a/PiPPl/Model/UpdateState.swift
+++ b/PiPPl/Model/UpdateState.swift
@@ -13,7 +13,7 @@ enum UpdateState {
     case recommended
     case required
 
-    func stateNoticeColor() -> Color {
+    var updateNotificationColor: Color {
         switch self {
             case .latest:
                 .clear

--- a/PiPPl/Model/UpdateState.swift
+++ b/PiPPl/Model/UpdateState.swift
@@ -25,4 +25,37 @@ enum UpdateState {
                 .red
         }
     }
+
+    var updateAlertTitle: String {
+        switch self {
+            case .latest:
+                AppText.latestVersionAlertTitle
+            case .available, .recommended:
+                AppText.updateAvailableAlertTitle
+            case .required:
+                AppText.oldVersionAlertTitle
+        }
+    }
+
+    var updateAlertBody: String {
+        switch self {
+            case .latest:
+                AppText.latestVersionAlertBody
+            case .available, .recommended:
+                AppText.updateAvailableAlertBody
+            case .required:
+                AppText.oldVersionAlertBody
+        }
+    }
+
+    var updateAlertPrimaryAction: String {
+        switch self {
+            case .latest:
+                AppText.confirm
+            case .available, .recommended:
+                AppText.updateAvailableAlertUpdateAction
+            case .required:
+                AppText.oldVersionAlertAction
+        }
+    }
 }

--- a/PiPPl/Model/UpdateState.swift
+++ b/PiPPl/Model/UpdateState.swift
@@ -1,0 +1,15 @@
+//
+//  UpdateState.swift
+//  PiPPl
+//
+//  Created by 김민택 on 5/3/25.
+//
+
+import SwiftUI
+
+enum UpdateState {
+    case latest
+    case available
+    case recommended
+    case required
+}

--- a/PiPPl/Model/UpdateState.swift
+++ b/PiPPl/Model/UpdateState.swift
@@ -12,4 +12,17 @@ enum UpdateState {
     case available
     case recommended
     case required
+
+    func stateNoticeColor() -> Color {
+        switch self {
+            case .latest:
+                .clear
+            case .available:
+                .accentColor
+            case .recommended:
+                .yellow
+            case .required:
+                .red
+        }
+    }
 }

--- a/PiPPl/Model/VersionModel.swift
+++ b/PiPPl/Model/VersionModel.swift
@@ -1,0 +1,37 @@
+//
+//  VersionModel.swift
+//  PiPPl
+//
+//  Created by 김민택 on 5/6/25.
+//
+
+struct Version: Comparable {
+    var major: Int
+    var minor: Int
+    var patch: Int
+    var versionString: String {
+        "\(major).\(minor).\(patch)"
+    }
+
+    init(major: Int, minor: Int, patch: Int) {
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+    }
+
+    init(_ major: Int, _ minor: Int, _ patch: Int) {
+        self.init(major: major, minor: minor, patch: patch)
+    }
+
+    init?(_ string: String) {
+        let versions = string.split(separator: ".").map { Int($0)! }
+        guard versions.count >= 3 else { return nil }
+        self.init(major: versions[0], minor: versions[1], patch: versions[2])
+    }
+
+    static func < (lhs: Version, rhs: Version) -> Bool {
+        if lhs.major != rhs.major { return lhs.major < rhs.major }
+        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+        return lhs.patch < rhs.patch
+    }
+}

--- a/PiPPl/PiPPlApp.swift
+++ b/PiPPl/PiPPlApp.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 @main
 struct PiPPlApp: App {
+    @StateObject private var appVersionManager = AppVersionManager()
 
     init() {
         let audioSession = AVAudioSession.sharedInstance()
@@ -24,6 +25,7 @@ struct PiPPlApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(appVersionManager)
         }
     }
 }

--- a/PiPPl/Resource/AppText.swift
+++ b/PiPPl/Resource/AppText.swift
@@ -58,6 +58,11 @@ enum AppText {
     static let oldVersionAlertBody = String(localized: "OldVersionAlertBody")
     static let oldVersionAlertAction = String(localized: "OldVersionAlertAction")
 
+    static let updateAvailableAlertTitle = String(localized: "UpdateAvailableAlertTitle")
+    static let updateAvailableAlertBody = String(localized: "UpdateAvailableAlertBody")
+    static let updateAvailableAlertUpdateAction = String(localized: "UpdateAvailableAlertUpdateAction")
+    static let updateAvailableAlertPostponeAction = String(localized: "UpdateAvailableAlertPostponeAction")
+
     static let latestVersionAlertTitle = String(localized: "LatestVersionAlertTitle")
     static let latestVersionAlertBody = String(localized: "LatestVersionAlertBody")
 

--- a/PiPPl/Resource/Localizable.xcstrings
+++ b/PiPPl/Resource/Localizable.xcstrings
@@ -9,10 +9,22 @@
             "value" : "%1$lld:%2$@"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
+    },
+    "%lld.%lld.%lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld.%2$lld.%3$lld"
+          }
+        }
+      },
+      "shouldTranslate" : false
     },
     "%lld%%" : {
-
+      "shouldTranslate" : false
     },
     "AppInfo" : {
       "extractionState" : "manual",

--- a/PiPPl/Resource/Localizable.xcstrings
+++ b/PiPPl/Resource/Localizable.xcstrings
@@ -12,17 +12,6 @@
       },
       "shouldTranslate" : false
     },
-    "%lld.%lld.%lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld.%2$lld.%3$lld"
-          }
-        }
-      },
-      "shouldTranslate" : false
-    },
     "%lld%%" : {
       "shouldTranslate" : false
     },

--- a/PiPPl/Resource/Localizable.xcstrings
+++ b/PiPPl/Resource/Localizable.xcstrings
@@ -449,13 +449,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "A new version of the app has been released.\nPlease update the app."
+            "value" : "The app is outdated or has an important update.\nPlease update the app."
           }
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "새로운 버전의 앱이 출시 되었습니다.\n업데이트 이후 사용해주세요."
+            "state" : "needs_review",
+            "value" : "사용하는 앱이 오래되었거나, 중요한 업데이트가 있습니다.\n업데이트 후 사용해주세요."
           }
         }
       }
@@ -466,13 +466,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Old Version"
+            "value" : "Important Update"
           }
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "구버전 알림"
+            "state" : "needs_review",
+            "value" : "중요 업데이트 알림"
           }
         }
       }
@@ -523,6 +523,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "여기에 주소를 입력해주세요."
+          }
+        }
+      }
+    },
+    "UpdateAvailableAlertBody" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A new version of the app has been released.\nPlease update the app."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "새로운 버전의 앱이 출시 되었습니다.\n업데이트 후 사용해주세요."
+          }
+        }
+      }
+    },
+    "UpdateAvailableAlertPostponeAction" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Later"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "다음에 하기"
+          }
+        }
+      }
+    },
+    "UpdateAvailableAlertTitle" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Update"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "업데이트 알림"
+          }
+        }
+      }
+    },
+    "UpdateAvailableAlertUpdateAction" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Now Update"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "지금 업데이트"
           }
         }
       }

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-class AppVersionManager {
     typealias Version = (major: Int, minor: Int, patch: Int)
+class AppVersionManager: ObservableObject {
 
     static let shared = AppVersionManager()
     let iTunesID: String

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -11,6 +11,9 @@ struct Version: Comparable {
     var major: Int
     var minor: Int
     var patch: Int
+    var versionString: String {
+        "\(major).\(minor).\(patch)"
+    }
 
     init(major: Int, minor: Int, patch: Int) {
         self.major = major

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -40,7 +40,6 @@ struct Version: Comparable {
 
 class AppVersionManager: ObservableObject {
 
-    static let shared = AppVersionManager()
     let iTunesID: String
     let downloadedAppVersion: Version
 

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -36,6 +36,16 @@ class AppVersionManager {
         }
     }
 
+    private func requestRequiredVersion() async throws -> String {
+        guard let url = URL(string: "https://raw.githubusercontent.com/taek0622/Version/refs/heads/main/PiPPl.json") else { return "" }
+        let (data, _) = try await URLSession.shared.data(from: url)
+        guard let json = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as? [String: Any],
+              let requiredVersion = json["requiredVersion"] as? String
+        else { return "" }
+
+        return requiredVersion
+    }
+
     private func requestLatestAppStoreVersion() async throws -> String {
         guard let url = URL(string: "https://itunes.apple.com/lookup?id=\(iTunesID)")
         else { return "" }

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -51,9 +51,9 @@ class AppVersionManager: ObservableObject {
         } else { self.iTunesID = "" }
 
         if let downloadedVersionString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
-           let versions = downloadedVersionString.stringToVersion() {
+           let versions = Version(downloadedVersionString) {
             self.downloadedAppVersion = versions
-        } else { self.downloadedAppVersion = (0, 0, 0) }
+        } else { self.downloadedAppVersion = .init(0, 0, 0) }
     }
 
     func checkNewUpdate() async -> UpdateState {
@@ -73,26 +73,26 @@ class AppVersionManager: ObservableObject {
     }
 
     private func requestRequiredVersion() async throws -> Version {
-        guard let url = URL(string: "https://raw.githubusercontent.com/taek0622/Version/refs/heads/main/PiPPl.json") else { return (0, 0, 0) }
+        guard let url = URL(string: "https://raw.githubusercontent.com/taek0622/Version/refs/heads/main/PiPPl.json") else { return .init(major: 0, minor: 0, patch: 0) }
         let (data, _) = try await URLSession.shared.data(from: url)
         guard let json = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as? [String: Any],
               let requiredVersionString = json["requiredVersion"] as? String,
-              let requiredVersion = requiredVersionString.stringToVersion()
-        else { return (0, 0, 0) }
+              let requiredVersion = Version(requiredVersionString)
+        else { return .init(0, 0, 0) }
 
         return requiredVersion
     }
 
     private func requestLatestAppStoreVersion() async throws -> Version {
         guard let url = URL(string: "https://itunes.apple.com/lookup?id=\(iTunesID)")
-        else { return (0, 0, 0) }
+        else { return .init(0, 0, 0) }
 
         let (data, _) = try await URLSession.shared.data(from: url)
         guard let json = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as? [String: Any],
               let results = json["results"] as? [[String: Any]],
               let latestAppStoreVersionString = results[0]["version"] as? String,
-              let latestAppStoreVersion = latestAppStoreVersionString.stringToVersion()
-        else { return (0, 0, 0) }
+              let latestAppStoreVersion = Version(latestAppStoreVersionString)
+        else { return .init(0, 0, 0) }
 
         return latestAppStoreVersion
     }

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -10,20 +10,18 @@ import Foundation
 class AppVersionManager {
 
     static let shared = AppVersionManager()
-    var iTunesID: String {
-        guard let filePath = Bundle.main.path(forResource: "Properties", ofType: "plist"),
-              let property = NSDictionary(contentsOfFile: filePath),
-              let iTunesID = property["iTunesID"] as? String
-        else { return "" }
+    let iTunesID: String
+    let downloadedAppVersion: String
 
-        return iTunesID
-    }
-    var downloadedAppVersion: String {
-        guard let downloadedAppVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { return "" }
-        return downloadedAppVersion
-    }
+    private init() {
+        if let filePath = Bundle.main.path(forResource: "Properties", ofType: "plist"),
+           let property = NSDictionary(contentsOfFile: filePath),
+           let iTunesID = property["iTunesID"] as? String {
+            self.iTunesID = iTunesID
+        } else { self.iTunesID = "" }
 
-    private init() {}
+        self.downloadedAppVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+    }
 
     func checkNewUpdate() async -> Bool {
         guard let latestAppStoreVersion = try? await requestLatestAppStoreVersion() else { return false }

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -60,3 +60,11 @@ class AppVersionManager {
         return latestAppStoreVersion
     }
 }
+
+extension String {
+    func stringToVersion() -> (major: Int, minor: Int, patch: Int)? {
+        let versions = self.split(separator: ".").map { Int($0)! }
+        guard versions.count >= 3 else { return nil }
+        return (versions[0], versions[1], versions[2])
+    }
+}

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -44,7 +44,7 @@ class AppVersionManager: ObservableObject {
     let iTunesID: String
     let downloadedAppVersion: Version
 
-    private init() {
+    init() {
         if let filePath = Bundle.main.path(forResource: "Properties", ofType: "plist"),
            let property = NSDictionary(contentsOfFile: filePath),
            let iTunesID = property["iTunesID"] as? String {

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -7,6 +7,12 @@
 
 import Foundation
 
+struct Version: Comparable {
+    var major: Int
+    var minor: Int
+    var patch: Int
+}
+
 class AppVersionManager: ObservableObject {
 
     static let shared = AppVersionManager()

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -39,6 +39,7 @@ struct Version: Comparable {
 }
 
 class AppVersionManager: ObservableObject {
+    @Published var updateState = UpdateState.latest
 
     let iTunesID: String
     let downloadedAppVersion: Version

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -28,6 +28,11 @@ struct Version: Comparable {
         self.init(major: versions[0], minor: versions[1], patch: versions[2])
     }
 
+    static func < (lhs: Version, rhs: Version) -> Bool {
+        if lhs.major != rhs.major { return lhs.major < rhs.major }
+        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+        return lhs.patch < rhs.patch
+    }
 }
 
 class AppVersionManager: ObservableObject {

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 class AppVersionManager {
+    typealias Version = (major: Int, minor: Int, patch: Int)
 
     static let shared = AppVersionManager()
     let iTunesID: String

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -40,25 +40,27 @@ class AppVersionManager {
         }
     }
 
-    private func requestRequiredVersion() async throws -> String {
-        guard let url = URL(string: "https://raw.githubusercontent.com/taek0622/Version/refs/heads/main/PiPPl.json") else { return "" }
+    private func requestRequiredVersion() async throws -> Version {
+        guard let url = URL(string: "https://raw.githubusercontent.com/taek0622/Version/refs/heads/main/PiPPl.json") else { return (0, 0, 0) }
         let (data, _) = try await URLSession.shared.data(from: url)
         guard let json = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as? [String: Any],
-              let requiredVersion = json["requiredVersion"] as? String
-        else { return "" }
+              let requiredVersionString = json["requiredVersion"] as? String,
+              let requiredVersion = requiredVersionString.stringToVersion()
+        else { return (0, 0, 0) }
 
         return requiredVersion
     }
 
-    private func requestLatestAppStoreVersion() async throws -> String {
+    private func requestLatestAppStoreVersion() async throws -> Version {
         guard let url = URL(string: "https://itunes.apple.com/lookup?id=\(iTunesID)")
-        else { return "" }
+        else { return (0, 0, 0) }
 
         let (data, _) = try await URLSession.shared.data(from: url)
         guard let json = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as? [String: Any],
               let results = json["results"] as? [[String: Any]],
-              let latestAppStoreVersion = results[0]["version"] as? String
-        else { return "" }
+              let latestAppStoreVersionString = results[0]["version"] as? String,
+              let latestAppStoreVersion = latestAppStoreVersionString.stringToVersion()
+        else { return (0, 0, 0) }
 
         return latestAppStoreVersion
     }

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -11,6 +11,17 @@ struct Version: Comparable {
     var major: Int
     var minor: Int
     var patch: Int
+
+    init(major: Int, minor: Int, patch: Int) {
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+    }
+
+    init(_ major: Int, _ minor: Int, _ patch: Int) {
+        self.init(major: major, minor: minor, patch: patch)
+    }
+
 }
 
 class AppVersionManager: ObservableObject {

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -40,6 +40,7 @@ struct Version: Comparable {
 
 class AppVersionManager: ObservableObject {
     @Published var updateState = UpdateState.latest
+    @Published var isUpdateAlertOpen = false
 
     let iTunesID: String
     let downloadedAppVersion: Version

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -69,7 +69,6 @@ class AppVersionManager: ObservableObject {
         } else if (latestAppStoreVersion.major == downloadedAppVersion.major && latestAppStoreVersion.minor > downloadedAppVersion.minor + 2) || (latestAppStoreVersion.major == downloadedAppVersion.major && latestAppStoreVersion.minor == downloadedAppVersion.minor && latestAppStoreVersion.patch > downloadedAppVersion.patch + 4) {
             return .recommended
         }
-        print(requireVersion, latestAppStoreVersion, downloadedAppVersion)
 
         return .available
     }

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -22,6 +22,12 @@ struct Version: Comparable {
         self.init(major: major, minor: minor, patch: patch)
     }
 
+    init?(_ string: String) {
+        let versions = string.split(separator: ".").map { Int($0)! }
+        guard versions.count >= 3 else { return nil }
+        self.init(major: versions[0], minor: versions[1], patch: versions[2])
+    }
+
 }
 
 class AppVersionManager: ObservableObject {
@@ -82,13 +88,5 @@ class AppVersionManager: ObservableObject {
         else { return (0, 0, 0) }
 
         return latestAppStoreVersion
-    }
-}
-
-extension String {
-    func stringToVersion() -> (major: Int, minor: Int, patch: Int)? {
-        let versions = self.split(separator: ".").map { Int($0)! }
-        guard versions.count >= 3 else { return nil }
-        return (versions[0], versions[1], versions[2])
     }
 }

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-    typealias Version = (major: Int, minor: Int, patch: Int)
 class AppVersionManager: ObservableObject {
 
     static let shared = AppVersionManager()

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -12,7 +12,7 @@ class AppVersionManager {
 
     static let shared = AppVersionManager()
     let iTunesID: String
-    let downloadedAppVersion: String
+    let downloadedAppVersion: Version
 
     private init() {
         if let filePath = Bundle.main.path(forResource: "Properties", ofType: "plist"),
@@ -21,7 +21,10 @@ class AppVersionManager {
             self.iTunesID = iTunesID
         } else { self.iTunesID = "" }
 
-        self.downloadedAppVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+        if let downloadedVersionString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+           let versions = downloadedVersionString.stringToVersion() {
+            self.downloadedAppVersion = versions
+        } else { self.downloadedAppVersion = (0, 0, 0) }
     }
 
     func checkNewUpdate() async -> Bool {

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class AppVersionManager: ObservableObject {
     @Published var updateState = UpdateState.latest
-    @Published var isUpdateAlertOpen = false
+    @Published var isUpdateAlertOpened = false
 
     let iTunesID: String
     let downloadedAppVersion: Version

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -7,37 +7,6 @@
 
 import Foundation
 
-struct Version: Comparable {
-    var major: Int
-    var minor: Int
-    var patch: Int
-    var versionString: String {
-        "\(major).\(minor).\(patch)"
-    }
-
-    init(major: Int, minor: Int, patch: Int) {
-        self.major = major
-        self.minor = minor
-        self.patch = patch
-    }
-
-    init(_ major: Int, _ minor: Int, _ patch: Int) {
-        self.init(major: major, minor: minor, patch: patch)
-    }
-
-    init?(_ string: String) {
-        let versions = string.split(separator: ".").map { Int($0)! }
-        guard versions.count >= 3 else { return nil }
-        self.init(major: versions[0], minor: versions[1], patch: versions[2])
-    }
-
-    static func < (lhs: Version, rhs: Version) -> Bool {
-        if lhs.major != rhs.major { return lhs.major < rhs.major }
-        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
-        return lhs.patch < rhs.patch
-    }
-}
-
 class AppVersionManager: ObservableObject {
     @Published var updateState = UpdateState.latest
     @Published var isUpdateAlertOpen = false

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -26,7 +26,7 @@ class AppVersionManager {
     private init() {}
 
     func checkNewUpdate() async -> Bool {
-        guard let latestAppStoreVersion = try? await getLatestAppStoreVersion() else { return false }
+        guard let latestAppStoreVersion = try? await requestLatestAppStoreVersion() else { return false }
 
         let compareResult = downloadedAppVersion.compare(latestAppStoreVersion, options: .numeric)
 
@@ -38,7 +38,7 @@ class AppVersionManager {
         }
     }
 
-    private func getLatestAppStoreVersion() async throws -> String {
+    private func requestLatestAppStoreVersion() async throws -> String {
         guard let url = URL(string: "https://itunes.apple.com/lookup?id=\(iTunesID)")
         else { return "" }
 

--- a/PiPPl/Utility/NetworkManager.swift
+++ b/PiPPl/Utility/NetworkManager.swift
@@ -20,7 +20,6 @@ final class NetworkManager {
 
         URLSession.shared.dataTask(with: urlRequest) { data, response, error in
             if let error {
-                print(error)
                 return
             }
 

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -18,6 +18,7 @@ struct AppInfoView: View {
         case versionInfo
     }
 
+    @EnvironmentObject var appVersionManager: AppVersionManager
     @State private var isOpenSafariView = false
     @State private var isOldVersion = false
     @State private var isSelectAppVersion = false
@@ -25,7 +26,6 @@ struct AppInfoView: View {
     @State private var url = URL(string: "https://www.google.com")!
     @State private var isMailSend = false
     @State private var isUnavailableMail = false
-    let appVersionManager = AppVersionManager.shared
 
     var body: some View {
         List {

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -87,8 +87,8 @@ struct AppInfoView: View {
         } message: {
             Text(AppText.latestVersionAlertBody)
         }
-        .alert(AppText.oldVersionAlertTitle, isPresented: $isOldVersion) {
-            Button(AppText.oldVersionAlertAction) {
+        .alert(updateState.updateAlertTitle, isPresented: $isOldVersion) {
+            Button(updateState.updateAlertPrimaryAction) {
                 let appStoreOpenURL = "itms-apps://itunes.apple.com/app/apple-store/\(appVersionManager.iTunesID)"
                 guard let url = URL(string: appStoreOpenURL) else { return }
                 if UIApplication.shared.canOpenURL(url) {
@@ -96,7 +96,7 @@ struct AppInfoView: View {
                 }
             }
         } message: {
-            Text(AppText.oldVersionAlertBody)
+            Text(updateState.updateAlertBody)
         }
     }
 }

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -61,7 +61,7 @@ struct AppInfoView: View {
                 HStack {
                     Text(AppText.versionInfo)
                     Spacer()
-                    Text("\(appVersionManager.downloadedAppVersion.major).\(appVersionManager.downloadedAppVersion.minor).\(appVersionManager.downloadedAppVersion.patch)")
+                    Text(appVersionManager.downloadedAppVersion.versionString)
                         .foregroundStyle(.gray)
                         .font(.system(size: 16))
                 }

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -95,6 +95,10 @@ struct AppInfoView: View {
                     UIApplication.shared.open(url)
                 }
             }
+
+            if updateState == .recommended || updateState == .available {
+                Button(AppText.updateAvailableAlertPostponeAction) {}
+            }
         } message: {
             Text(updateState.updateAlertBody)
         }

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -19,8 +19,9 @@ struct AppInfoView: View {
     }
 
     @State private var isOpenSafariView = false
-    @State private var isSelectAppVersion = false
     @State private var isOldVersion = false
+    @State private var isSelectAppVersion = false
+    @State private var updateState: UpdateState = .latest
     @State private var url = URL(string: "https://www.google.com")!
     @State private var isMailSend = false
     @State private var isUnavailableMail = false
@@ -48,14 +49,19 @@ struct AppInfoView: View {
             }
             Button {
                 Task {
-                    isOldVersion = await appVersionManager.checkNewUpdate()
-                    isSelectAppVersion = !isOldVersion
+                    updateState = await appVersionManager.checkNewUpdate()
+
+                    if updateState == .latest {
+                        isSelectAppVersion = true
+                    } else {
+                        isOldVersion = true
+                    }
                 }
             } label: {
                 HStack {
                     Text(AppText.versionInfo)
                     Spacer()
-                    Text(appVersionManager.downloadedAppVersion)
+                    Text("\(appVersionManager.downloadedAppVersion.major).\(appVersionManager.downloadedAppVersion.minor).\(appVersionManager.downloadedAppVersion.patch)")
                         .foregroundStyle(.gray)
                         .font(.system(size: 16))
                 }

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -102,7 +102,7 @@ struct LocalVideoGalleryView: View {
                     isUpdateAlertOpen = true
                 } label: {
                     Image(systemName: "arrow.up.square.fill")
-                        .foregroundStyle(updateState.stateNoticeColor())
+                        .foregroundStyle(updateState.updateNotificationColor)
                 }
 
             }

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -9,6 +9,7 @@ import Photos
 import SwiftUI
 
 struct LocalVideoGalleryView: View {
+    @AppStorage("updateAlertCount") var updateAlertCount: Int = 0
     @State private var isPermissionAccessable = false
     @State private var updateState: UpdateState = .latest
     @State private var isUpdateAlertOpen = false
@@ -141,6 +142,15 @@ struct LocalVideoGalleryView: View {
                 if updateState == .required && !appVersionManager.isUpdateAlertOpen {
                     isUpdateAlertOpen = true
                     appVersionManager.isUpdateAlertOpen = true
+                } else if updateState == .recommended && !appVersionManager.isUpdateAlertOpen {
+                    if updateAlertCount == 0 {
+                        isUpdateAlertOpen = true
+                        appVersionManager.isUpdateAlertOpen = true
+                    }
+
+                    updateAlertCount += 1
+
+                    if updateAlertCount == 3 { updateAlertCount = 0 }
                 }
             }
         }

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -13,8 +13,8 @@ struct LocalVideoGalleryView: View {
     @State private var updateState: UpdateState = .latest
     @State private var isUpdateAlertOpen = false
     @StateObject private var libraryManager = LocalVideoLibraryManager.shared
+    @EnvironmentObject var appVersionManager: AppVersionManager
     @Environment(\.colorScheme) private var colorScheme
-    private let appVersionManager = AppVersionManager.shared
     var rowItemCount: Double {
         if UIDevice.current.userInterfaceIdiom == .phone {
             if UIDevice.current.orientation == .portrait {

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -115,6 +115,10 @@ struct LocalVideoGalleryView: View {
                     UIApplication.shared.open(url)
                 }
             }
+
+            if updateState == .recommended || updateState == .available {
+                Button(AppText.updateAvailableAlertPostponeAction) {}
+            }
         } message: {
             Text(updateState.updateAlertBody)
         }

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -107,8 +107,8 @@ struct LocalVideoGalleryView: View {
 
             }
         }
-        .alert(AppText.oldVersionAlertTitle, isPresented: $isUpdateAlertOpen) {
-            Button(AppText.oldVersionAlertAction) {
+        .alert(updateState.updateAlertTitle, isPresented: $isUpdateAlertOpen) {
+            Button(updateState.updateAlertPrimaryAction) {
                 let appStoreOpenURL = "itms-apps://itunes.apple.com/app/apple-store/\(appVersionManager.iTunesID)"
                 guard let url = URL(string: appStoreOpenURL) else { return }
                 if UIApplication.shared.canOpenURL(url) {
@@ -116,7 +116,7 @@ struct LocalVideoGalleryView: View {
                 }
             }
         } message: {
-            Text(AppText.oldVersionAlertBody)
+            Text(updateState.updateAlertBody)
         }
         .onAppear {
             switch libraryManager.status {

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -139,13 +139,13 @@ struct LocalVideoGalleryView: View {
             Task {
                 updateState = await appVersionManager.checkNewUpdate()
 
-                if updateState == .required && !appVersionManager.isUpdateAlertOpen {
+                if updateState == .required && !appVersionManager.isUpdateAlertOpened {
                     isUpdateAlertOpen = true
-                    appVersionManager.isUpdateAlertOpen = true
-                } else if updateState == .recommended && !appVersionManager.isUpdateAlertOpen {
+                    appVersionManager.isUpdateAlertOpened = true
+                } else if updateState == .recommended && !appVersionManager.isUpdateAlertOpened {
                     if updateAlertCount == 0 {
                         isUpdateAlertOpen = true
-                        appVersionManager.isUpdateAlertOpen = true
+                        appVersionManager.isUpdateAlertOpened = true
                     }
 
                     updateAlertCount += 1

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -137,6 +137,11 @@ struct LocalVideoGalleryView: View {
 
             Task {
                 updateState = await appVersionManager.checkNewUpdate()
+
+                if updateState == .required && !appVersionManager.isUpdateAlertOpen {
+                    isUpdateAlertOpen = true
+                    appVersionManager.isUpdateAlertOpen = true
+                }
             }
         }
     }

--- a/PiPPl/View/NetworkVideo/NetworkPlayerViewController.swift
+++ b/PiPPl/View/NetworkVideo/NetworkPlayerViewController.swift
@@ -37,25 +37,6 @@ class NetworkPlayerViewController: UIViewController {
         loadURLWeb("https://www.google.com")
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        Task {
-            switch await appVersionManager.checkNewUpdate() {
-            case true:
-                let appStoreOpenURL = "itms-apps://itunes.apple.com/app/apple-store/\(appVersionManager.iTunesID)"
-                let alert = UIAlertController(title: AppText.oldVersionAlertTitle, message: AppText.oldVersionAlertBody, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: AppText.oldVersionAlertAction, style: .default, handler: { action in
-                    guard let url = URL(string: appStoreOpenURL) else { return }
-                    if UIApplication.shared.canOpenURL(url) {
-                        UIApplication.shared.open(url)
-                    }
-                }))
-                present(alert, animated: true)
-            case false:
-                break
-            }
-        }
-    }
-
     // MARK: - Method
 
     private func layout() {

--- a/PiPPl/View/NetworkVideo/NetworkPlayerViewController.swift
+++ b/PiPPl/View/NetworkVideo/NetworkPlayerViewController.swift
@@ -51,7 +51,6 @@ class NetworkPlayerViewController: UIViewController {
             guard let filePath = Bundle.main.path(forResource: "Properties", ofType: "plist") else { return }
             guard let property = NSDictionary(contentsOfFile: filePath) else { return }
             guard let pipLogic = property["PiPLogic"] as? String else { return }
-            print(pipLogic)
             self.webView.evaluateJavaScript(pipLogic)
         })
         navigationItem.titleView = searchTextField
@@ -228,7 +227,6 @@ class NetworkPlayerViewController: UIViewController {
                 urlString = "https://" + urlString
             } else {
                 urlString = "https://www.google.com/search?q=" + urlString
-                print(splitDomain.last!)
             }
         }
 

--- a/PiPPl/View/NetworkVideo/NetworkPlayerViewController.swift
+++ b/PiPPl/View/NetworkVideo/NetworkPlayerViewController.swift
@@ -10,10 +10,6 @@ import WebKit
 
 class NetworkPlayerViewController: UIViewController {
 
-    // MARK: - Proeprties
-
-    private let appVersionManager = AppVersionManager.shared
-
     // MARK: - View
 
     private var webView: WKWebView!


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 업데이트 알림 방식을 세분화하고, 불필요하게 자주 업데이트 알림을 보게하지 않기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- `AppVersionManager` `Singleton`에서 `ObservableObject`로 변경
- `Version` 모델 추가
- 앱스토어에 출시된 최신 버전을 가져오는 메서드 이름을 `getLatestAppStoreVersion`에서 `requestLatestAppStoreVersion`으로 변경
- 앱 실행 중에는 변하지 않는 `iTunesID`와 `downloadedAppVersion` 변수를 클래스 초기화시에 값 설정하고 변경되지 않도록 변경
- 최소 업데이트 요구 버전을 가져오는 `reqeustRequiredVersion` 메서드 추가
- 업데이트 알림을 관리하기 위한 `UpdateState` 모델 추가
- 앱 업데이트 알림 주기 변경
- 불필요한 코드 정리

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗

## Close Issues 🔒 (닫을 Issue)
Close #46.
