### PR TITLE
[Refactor] 콜백 클로저 기반 메서드 async/await 형식으로 변경

### DIFF
--- a/PiPPl.xcodeproj/project.pbxproj
+++ b/PiPPl.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		2649A4BD2C066280007FCC55 /* NoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2649A4BC2C066280007FCC55 /* NoticeView.swift */; };
 		2683F5512B583E3C00C1CEEB /* LocalVideoLibraryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2683F5502B583E3C00C1CEEB /* LocalVideoLibraryManager.swift */; };
 		26B742AD2BA736A800823338 /* NoticeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B742AC2BA736A800823338 /* NoticeModel.swift */; };
-		26B742AF2BA736C200823338 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B742AE2BA736C200823338 /* NetworkManager.swift */; };
+		26B742AF2BA736C200823338 /* NoticeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B742AE2BA736C200823338 /* NoticeViewModel.swift */; };
 		26DA7D4C2BB5D059002AF316 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 26DA7D4B2BB5D059002AF316 /* Localizable.xcstrings */; };
 		26DA7D512BB5D3A3002AF316 /* AppText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DA7D502BB5D3A3002AF316 /* AppText.swift */; };
 		26DA7D532BB5DD77002AF316 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 26DA7D522BB5DD77002AF316 /* InfoPlist.xcstrings */; };
@@ -40,7 +40,7 @@
 		2649A4BC2C066280007FCC55 /* NoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeView.swift; sourceTree = "<group>"; };
 		2683F5502B583E3C00C1CEEB /* LocalVideoLibraryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalVideoLibraryManager.swift; sourceTree = "<group>"; };
 		26B742AC2BA736A800823338 /* NoticeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeModel.swift; sourceTree = "<group>"; };
-		26B742AE2BA736C200823338 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
+		26B742AE2BA736C200823338 /* NoticeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeViewModel.swift; sourceTree = "<group>"; };
 		26DA7D492BB5CF53002AF316 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		26DA7D4B2BB5D059002AF316 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		26DA7D502BB5D3A3002AF316 /* AppText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppText.swift; sourceTree = "<group>"; };
@@ -109,7 +109,7 @@
 				2683F5502B583E3C00C1CEEB /* LocalVideoLibraryManager.swift */,
 				26EBB1952BC728B600C83CA2 /* AppVersionManager.swift */,
 				263F037E2B598DFB00EAC60E /* LocalVideoPlayer.swift */,
-				26B742AE2BA736C200823338 /* NetworkManager.swift */,
+				26B742AE2BA736C200823338 /* NoticeViewModel.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -250,7 +250,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				26B742AF2BA736C200823338 /* NetworkManager.swift in Sources */,
+				26B742AF2BA736C200823338 /* NoticeViewModel.swift in Sources */,
 				26DA7D512BB5D3A3002AF316 /* AppText.swift in Sources */,
 				26E801D12DB5193100CE20BB /* LocalPlayerViewController.swift in Sources */,
 				26EBB1CE2BE26A3500C83CA2 /* LocalVideoPlayView.swift in Sources */,

--- a/PiPPl/Model/NoticeModel.swift
+++ b/PiPPl/Model/NoticeModel.swift
@@ -11,3 +11,10 @@ struct Notice: Codable, Hashable {
     let content: String
     let createDate: String
 }
+
+struct NoticeItem: Hashable, Identifiable {
+    var id: Self { self }
+    var title: String
+    var date: String? = nil
+    var content: [NoticeItem]? = nil
+}

--- a/PiPPl/Resource/Localizable.xcstrings
+++ b/PiPPl/Resource/Localizable.xcstrings
@@ -443,7 +443,7 @@
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "사용하는 앱이 오래되었거나, 중요한 업데이트가 있습니다.\n업데이트 후 사용해주세요."
           }
         }
@@ -460,7 +460,7 @@
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "중요 업데이트 알림"
           }
         }
@@ -542,7 +542,7 @@
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "다음에 하기"
           }
         }
@@ -558,7 +558,7 @@
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "업데이트 알림"
           }
         }
@@ -574,7 +574,7 @@
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "지금 업데이트"
           }
         }

--- a/PiPPl/Utility/LocalVideoPlayer.swift
+++ b/PiPPl/Utility/LocalVideoPlayer.swift
@@ -28,7 +28,6 @@ class LocalVideoPlayer: ObservableObject {
 
     // MARK: - Method
 
-    func configureVideo(_ asset: PHAsset) {
         let option = PHVideoRequestOptions()
         option.isNetworkAccessAllowed = true
         option.version = .original
@@ -40,6 +39,7 @@ class LocalVideoPlayer: ObservableObject {
             DispatchQueue.main.async {
                 self.videoLoadProgress = Double(progress)
             }
+    func configureVideo(_ asset: PHAsset) async {
         }
 
         PHImageManager.default().requestPlayerItem(forVideo: asset, options: option) { playerItem, info in

--- a/PiPPl/Utility/LocalVideoPlayer.swift
+++ b/PiPPl/Utility/LocalVideoPlayer.swift
@@ -51,15 +51,11 @@ class LocalVideoPlayer: ObservableObject {
                 .sink { [weak self] status in
                     if status == .readyToPlay {
                         self?.isVideoLoading = false
-                        self?.play()
+                        self?.player.play()
                     }
                 }
         }
 
-    }
-
-    func play() {
-        player.play()
     }
 
     func pause() {

--- a/PiPPl/Utility/LocalVideoPlayer.swift
+++ b/PiPPl/Utility/LocalVideoPlayer.swift
@@ -82,21 +82,4 @@ class LocalVideoPlayer: ObservableObject {
         }
     }
 
-    func changePlayingFrame(_ playingProgress: Double) {
-        guard let duration = self.player.currentItem?.duration.seconds else { return }
-        player.seek(to: CMTime(value: CMTimeValue(duration * playingProgress), timescale: 1))
-    }
-
-    func playForward(_ playingProgress: Double) {
-        guard let duration = self.player.currentItem?.duration.seconds else { return }
-        let chaingingTime = CMTimeAdd(CMTime(value: CMTimeValue(duration * playingProgress), timescale: 1), CMTime(value: 10, timescale: 1))
-        player.seek(to: chaingingTime)
-    }
-
-    func playBackward(_ playingProgress: Double) {
-        guard let duration = self.player.currentItem?.duration.seconds else { return }
-        let chaingTime = CMTimeSubtract(CMTime(value: CMTimeValue(duration * playingProgress), timescale: 1), CMTime(value: 10, timescale: 1))
-        player.seek(to: chaingTime)
-    }
-
 }

--- a/PiPPl/Utility/LocalVideoPlayer.swift
+++ b/PiPPl/Utility/LocalVideoPlayer.swift
@@ -17,12 +17,14 @@ class LocalVideoPlayer: ObservableObject {
     @Published var videoLoadProgress: Double = 0.0
     private var statusCancellable: AnyCancellable?
 
-    lazy var player: AVPlayer = {
+    private lazy var player: AVPlayer = {
         $0.actionAtItemEnd = .pause
         return $0
     }(AVPlayer())
 
-    lazy var playerLayer = AVPlayerLayer(player: player)
+    var playerInstance: AVPlayer {
+        return player
+    }
 
     var status: AVPlayer.TimeControlStatus {
         player.timeControlStatus

--- a/PiPPl/Utility/LocalVideoPlayer.swift
+++ b/PiPPl/Utility/LocalVideoPlayer.swift
@@ -17,14 +17,10 @@ class LocalVideoPlayer: ObservableObject {
     @Published var videoLoadProgress: Double = 0.0
     private var statusCancellable: AnyCancellable?
 
-    private lazy var player: AVPlayer = {
+    lazy var player: AVPlayer = {
         $0.actionAtItemEnd = .pause
         return $0
     }(AVPlayer())
-
-    var playerInstance: AVPlayer {
-        return player
-    }
 
     var status: AVPlayer.TimeControlStatus {
         player.timeControlStatus

--- a/PiPPl/Utility/LocalVideoPlayer.swift
+++ b/PiPPl/Utility/LocalVideoPlayer.swift
@@ -17,8 +17,6 @@ class LocalVideoPlayer: ObservableObject {
     @Published var videoLoadProgress: Double = 0.0
     private var statusCancellable: AnyCancellable?
 
-    static let shared = LocalVideoPlayer()
-
     lazy var player: AVPlayer = {
         $0.actionAtItemEnd = .pause
         return $0
@@ -29,10 +27,6 @@ class LocalVideoPlayer: ObservableObject {
     var status: AVPlayer.TimeControlStatus {
         player.timeControlStatus
     }
-
-    // MARK: - Initializer
-
-    private init() {}
 
     // MARK: - Method
 

--- a/PiPPl/Utility/LocalVideoPlayer.swift
+++ b/PiPPl/Utility/LocalVideoPlayer.swift
@@ -59,8 +59,11 @@ class LocalVideoPlayer: ObservableObject {
                         if status == .readyToPlay {
                             timer.cancel()
                             self?.videoLoadProgress = 1.0
-                            self?.isVideoLoading = false
-                            self?.player.play()
+                            Task { @MainActor in
+                                try await Task.sleep(nanoseconds: 50_000_000)
+                                self?.isVideoLoading = false
+                                self?.player.play()
+                            }
                         }
                     }
             }

--- a/PiPPl/Utility/LocalVideoPlayer.swift
+++ b/PiPPl/Utility/LocalVideoPlayer.swift
@@ -41,11 +41,11 @@ class LocalVideoPlayer: ObservableObject {
                 self.player.replaceCurrentItem(with: playerItem)
 
                 let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.main)
-                timer.schedule(deadline: .now(), repeating: 0.1)
+                timer.schedule(deadline: .now(), repeating: 0.05)
                 timer.setEventHandler { [weak self] in
                     guard let self else { return }
 
-                    if self.videoLoadProgress <= 0.95 {
+                    if self.videoLoadProgress <= 0.96 {
                         self.videoLoadProgress += 0.01
                     } else {
                         timer.cancel()
@@ -79,7 +79,7 @@ class LocalVideoPlayer: ObservableObject {
             options.deliveryMode = .highQualityFormat
             options.progressHandler = { progress, _, _, _ in
                 Task { @MainActor in
-                    self.videoLoadProgress = Double(progress) * 0.5
+                    self.videoLoadProgress = Double(progress) * 0.2
                 }
             }
 

--- a/PiPPl/Utility/LocalVideoPlayer.swift
+++ b/PiPPl/Utility/LocalVideoPlayer.swift
@@ -55,7 +55,9 @@ class LocalVideoPlayer: ObservableObject {
                     }
                 }
         }
+    }
 
+    func requestPlayerItem(asset: PHAsset) async throws -> AVPlayerItem {
     }
 
     func pause() {

--- a/PiPPl/Utility/NetworkManager.swift
+++ b/PiPPl/Utility/NetworkManager.swift
@@ -10,6 +10,7 @@ import Foundation
 @MainActor
 final class NetworkManager: ObservableObject {
 
+    @Published var notices = [NoticeItem]()
 
     func requestNoticeData() async {
         guard let url = URL(string: "https://raw.githubusercontent.com/taek0622/Notice/main/notice.json") else { return }

--- a/PiPPl/Utility/NetworkManager.swift
+++ b/PiPPl/Utility/NetworkManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@MainActor
 final class NetworkManager: ObservableObject {
 
 

--- a/PiPPl/Utility/NetworkManager.swift
+++ b/PiPPl/Utility/NetworkManager.swift
@@ -10,8 +10,6 @@ import Foundation
 final class NetworkManager: ObservableObject {
 
 
-    private init() {}
-
     func requestNoticeData() async {
         guard let url = URL(string: "https://raw.githubusercontent.com/taek0622/Notice/main/notice.json") else { return }
         var urlRequest = URLRequest(url: url)

--- a/PiPPl/Utility/NetworkManager.swift
+++ b/PiPPl/Utility/NetworkManager.swift
@@ -7,9 +7,8 @@
 
 import Foundation
 
-final class NetworkManager {
+final class NetworkManager: ObservableObject {
 
-    static let shared = NetworkManager()
 
     private init() {}
 

--- a/PiPPl/Utility/NetworkManager.swift
+++ b/PiPPl/Utility/NetworkManager.swift
@@ -18,11 +18,7 @@ final class NetworkManager {
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "GET"
 
-        URLSession.shared.dataTask(with: urlRequest) { data, response, error in
-            if let error {
-                return
-            }
-
+        URLSession.shared.dataTask(with: urlRequest) { data, _, _ in
             guard let data = data else { return }
             let responseData = try! JSONDecoder().decode([Notice].self, from: data)
             completion(responseData)

--- a/PiPPl/Utility/NetworkManager.swift
+++ b/PiPPl/Utility/NetworkManager.swift
@@ -12,16 +12,18 @@ final class NetworkManager: ObservableObject {
 
     private init() {}
 
-    func requestNoticeData(completion: @escaping ([Notice]) -> Void) {
+    func requestNoticeData() async {
         guard let url = URL(string: "https://raw.githubusercontent.com/taek0622/Notice/main/notice.json") else { return }
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "GET"
 
-        URLSession.shared.dataTask(with: urlRequest) { data, _, _ in
-            guard let data = data else { return }
-            let responseData = try! JSONDecoder().decode([Notice].self, from: data)
-            completion(responseData)
+        do {
+            let (data, _) = try await URLSession.shared.data(for: urlRequest)
+            let responseData = try JSONDecoder().decode([Notice].self, from: data)
+
+            self.notices = responseData.map { NoticeItem(title: $0.title, date: $0.createDate, content: [NoticeItem(title: $0.content)]) }
+        } catch {
+            print("error")
         }
-        .resume()
     }
 }

--- a/PiPPl/Utility/NoticeViewModel.swift
+++ b/PiPPl/Utility/NoticeViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @MainActor
-final class NetworkManager: ObservableObject {
+final class NoticeViewModel: ObservableObject {
 
     @Published var notices = [NoticeItem]()
 

--- a/PiPPl/View/AppInfo/NoticeView.swift
+++ b/PiPPl/View/AppInfo/NoticeView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct NoticeView: View {
 
-    let networkManager = NetworkManager.shared
     @State private var item = [NoticeItem]()
+    @StateObject var networkManager = NetworkManager()
 
     var body: some View {
         List(item.reversed(), children: \.content) { item in

--- a/PiPPl/View/AppInfo/NoticeView.swift
+++ b/PiPPl/View/AppInfo/NoticeView.swift
@@ -8,12 +8,6 @@
 import SwiftUI
 
 struct NoticeView: View {
-    struct NoticeItem: Hashable, Identifiable {
-        var id: Self { self }
-        var title: String
-        var date: String? = nil
-        var content: [NoticeItem]? = nil
-    }
 
     let networkManager = NetworkManager.shared
     @State private var item = [NoticeItem]()

--- a/PiPPl/View/AppInfo/NoticeView.swift
+++ b/PiPPl/View/AppInfo/NoticeView.swift
@@ -9,11 +9,10 @@ import SwiftUI
 
 struct NoticeView: View {
 
-    @State private var item = [NoticeItem]()
     @StateObject var networkManager = NetworkManager()
 
     var body: some View {
-        List(item.reversed(), children: \.content) { item in
+        List(networkManager.notices.reversed(), children: \.content) { item in
             VStack(alignment: .leading) {
                 if item.date != nil {
                     Text(item.date!)

--- a/PiPPl/View/AppInfo/NoticeView.swift
+++ b/PiPPl/View/AppInfo/NoticeView.swift
@@ -9,10 +9,10 @@ import SwiftUI
 
 struct NoticeView: View {
 
-    @StateObject var networkManager = NetworkManager()
+    @StateObject var noticeViewModel = NoticeViewModel()
 
     var body: some View {
-        List(networkManager.notices.reversed(), children: \.content) { item in
+        List(noticeViewModel.notices.reversed(), children: \.content) { item in
             VStack(alignment: .leading) {
                 if item.date != nil {
                     Text(item.date!)
@@ -25,7 +25,7 @@ struct NoticeView: View {
             }
         }
         .task {
-            await networkManager.requestNoticeData()
+            await noticeViewModel.requestNoticeData()
         }
         .listStyle(.grouped)
         .navigationTitle(AppText.notice)

--- a/PiPPl/View/AppInfo/NoticeView.swift
+++ b/PiPPl/View/AppInfo/NoticeView.swift
@@ -25,17 +25,11 @@ struct NoticeView: View {
                     .font(.system(size: 17))
             }
         }
+        .task {
+            await networkManager.requestNoticeData()
+        }
         .listStyle(.grouped)
         .navigationTitle(AppText.notice)
-        .onAppear {
-            item = []
-
-            networkManager.requestNoticeData { notices in
-                for notice in notices {
-                    item.append(NoticeItem(title: notice.title, date: notice.createDate, content: [NoticeItem(title: notice.content)]))
-                }
-            }
-        }
     }
 }
 

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -43,8 +43,10 @@ struct LocalVideoGalleryView: View {
                         case .notDetermined, .restricted, .denied:
                             isPermissionAccessable = false
                         case .authorized, .limited:
-                            libraryManager.configureGallery()
-                            isPermissionAccessable = true
+                            Task {
+                                await libraryManager.configureGallery()
+                                isPermissionAccessable = true
+                            }
                         @unknown default:
                             break
                         }
@@ -52,7 +54,9 @@ struct LocalVideoGalleryView: View {
                 }
             } else if libraryManager.videos.isEmpty {
                 Button(AppText.photoGalleryNoVideoButtonText) {
-                    libraryManager.configureGallery()
+                    Task {
+                        await libraryManager.configureGallery()
+                    }
                 }
             } else {
                 ScrollView {
@@ -130,7 +134,9 @@ struct LocalVideoGalleryView: View {
             case .authorized, .limited:
                 isPermissionAccessable = true
                 if libraryManager.videos.isEmpty {
-                    libraryManager.configureGallery()
+                    Task {
+                        await libraryManager.configureGallery()
+                    }
                 }
             @unknown default:
                 break

--- a/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
@@ -36,7 +36,9 @@ struct LocalVideoPlayView: View {
         }
         .onAppear {
             if !isPresented {
-                localVideoPlayer.configureVideo(asset)
+                Task {
+                    await localVideoPlayer.configureVideo(asset)
+                }
             }
         }
         .onDisappear {

--- a/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
@@ -16,7 +16,7 @@ struct LocalVideoPlayView: View {
 
     var body: some View {
         ZStack {
-            LocalPlayerView(player: localVideoPlayer.playerInstance)
+            LocalPlayerView(player: localVideoPlayer.player)
 
             if localVideoPlayer.isVideoLoading {
                 Color(colorScheme == .light ? #colorLiteral(red: 0.2196078431, green: 0.2196078431, blue: 0.2196078431, alpha: 1) : #colorLiteral(red: 0.5490196078, green: 0.5490196078, blue: 0.5490196078, alpha: 1))

--- a/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct LocalVideoPlayView: View {
     @StateObject private var localVideoPlayer = LocalVideoPlayer()
     @Environment(\.colorScheme) var colorScheme
+    @Environment(\.isPresented) var isPresented
     var asset: PHAsset
 
     var body: some View {
@@ -34,10 +35,14 @@ struct LocalVideoPlayView: View {
             }
         }
         .onAppear {
-            localVideoPlayer.configureVideo(asset)
+            if !isPresented {
+                localVideoPlayer.configureVideo(asset)
+            }
         }
         .onDisappear {
-            localVideoPlayer.pause()
+            if !isPresented {
+                localVideoPlayer.pause()
+            }
         }
     }
 }

--- a/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
@@ -16,7 +16,7 @@ struct LocalVideoPlayView: View {
 
     var body: some View {
         ZStack {
-            LocalPlayerView(player: localVideoPlayer.player)
+            LocalPlayerView(player: localVideoPlayer.playerInstance)
 
             if localVideoPlayer.isVideoLoading {
                 Color(colorScheme == .light ? #colorLiteral(red: 0.2196078431, green: 0.2196078431, blue: 0.2196078431, alpha: 1) : #colorLiteral(red: 0.5490196078, green: 0.5490196078, blue: 0.5490196078, alpha: 1))

--- a/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
@@ -10,7 +10,7 @@ import Photos
 import SwiftUI
 
 struct LocalVideoPlayView: View {
-    @StateObject private var localVideoPlayer = LocalVideoPlayer.shared
+    @StateObject private var localVideoPlayer = LocalVideoPlayer()
     @Environment(\.colorScheme) var colorScheme
     var asset: PHAsset
 


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 가독성 향상을 위해 콜백 클로저 기반으로 작성된 메서드를 async/await 형식으로 변경하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- `LocalVideoPlayer` 클래스 관련
    - 싱글톤 삭제
    - 동기 메서드 `configureVideo(_:)`를 비동기 메서드로 변경
        - `configureVideo(_:)`를 동기적으로 사용하던 부분에 `Task`를 적용하여 비동기로 동작하도록 함
    - `configureVideo(_:)`를 실제로 비디오를 변경하는 `configureVideo(_:)`와 `PHAsset`에서 `AVPlayerItem`으로 변환하는 `requestPlayerItem(asset:)` 메서드로 분리
    - `requsetPlayerItem(asset:)` 메서드 내부의 `PHImageManager.default().requestPlayerItem(forVideo:options:)` 콜백 클로저 기반 메서드를 `withCheckedThrowingContinuation`으로 래핑하여 `async/await` 방식으로 사용할 수 있게 변경
    - 동기 메서드 `requestThumbnail(_:)`를 비동기 메서드로 변경
        - 메서드 내부의 `PHImageManager.default().requestImage(for:targetSize:contentMode:options:)` 콜백 클로저 기반 메서드를 `withCheckedContinuation`으로 래핑하여 `async/await` 방식으로 사용할 수 있게 변경
- `LocalVideoLibraryManager` 클래스 관련
    - 동기 메서드 `configureGallery()`를 비동기 메서드로 변경
        - 기존에 `configureGallery()` 메서드를 동기적으로 사용하던 부분에 `Task`를 적용하여 비동기로 동작하도록 함
    - 동기 메서드 `updateVideos(_:)`를 비동기 메서드로 변경
        - `MainActor.run`, `withTaskGroup(of:)` 적용
    - `photoLibraryDidChange(_:)` 옵저버 메서드 내부에 있는 `DispatchQueue.main.async`를 `Task`로 변경
- `NetworkManager` 클래스 관련
    - `NoticeItem` 모델 위치 `NoticeModel.swift` 파일로 이동
    - 싱글톤에서 `ObservableObject`로 변경 및 사용 부분 일반 `let`에서 `@StateObject`로 변경
    - `requestNoticeData(completion:)` 메서드를 콜백 클로저 기반에서 `async` 형식의 `requestNoticeData() async` 메서드로 변경
    - 메인 스레드에서 동작하도록 `@MainActor` 추가
    - `NoticeView`에서 `requestNoticeData()` 메서드를 호출할 때, 뷰가 화면에 보일 때마다 호출되는 게 아닌 화면에 처음 보일 때 한 번만 호출될 수 있도록 `.onAppear()` 내부에서 `.task()` 내부로 위치 변경
    - `NoticeView`에 사용되는 `Notice` 리스트를 뷰 내부의 `@State` 변수인 `item` 배열에서 `NetworkManager`의 `@Published` 변수 `notices` 배열을 사용하도록 변경
    - `NetworkManager`의 이름을 더 용도에 직관적인 이름인 `NoticeViewModel`로 변경
- 기타 수정 사항
    - 불필요한 코드 정리
    - 영상을 풀 커버 모달 플레이어로 보면 영상이 해제되는 문제 해결
    - 풀 커버 모달에서 일반 플레이어로 돌아오면 영상을 다시 다운로드 받는 문제 해결
    - 영상의 진행률이 한 번에 0%에서 100%로 올라가지 않고, 진행에 따라 올라가도록 수정
    - 진행률이 100%가 된 후, 0.05초 동안 진행률을 보여줄 수 있도록 `Task.sleep()` 적용

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗
- [Apple Developer Documentation/Combine/ObservableObject](https://developer.apple.com/documentation/combine/observableobject)
- [Apple Developer Documentation/Combine/Published](https://developer.apple.com/documentation/combine/published)
- [Apple Developer Documentation/SwiftUI/StateObject](https://developer.apple.com/documentation/swiftui/stateobject)
- [Apple Developer Documentation/SwiftUI/View/task(priority:_:)](https://developer.apple.com/documentation/swiftui/view/task(priority:_:))
- [Apple Developer Documentation/Swift/Task](https://developer.apple.com/documentation/swift/task)
- [Apple Developer Documentation/Swift/withCheckedContinuation(isolation:function:_:)](https://developer.apple.com/documentation/swift/withcheckedcontinuation(isolation:function:_:))
- [Apple Developer Documentation/Swift/withCheckedThrowingContinuation(isolation:function:_:)](https://developer.apple.com/documentation/swift/withcheckedthrowingcontinuation(isolation:function:_:))
- [Apple Developer Documentaion/Swift/MainActor](https://developer.apple.com/documentation/swift/mainactor)
- [Apple Developer Documentation/Swift/MainActor/run(resultType:body:)](https://developer.apple.com/documentation/swift/mainactor/run(resulttype:body:))
- [Apple Developer Documentation/Swift/withTaskGroup(of:returning:isolation:body:)](https://developer.apple.com/documentation/swift/withtaskgroup(of:returning:isolation:body:))
- [Apple Developer Documentation/Photos/PHPhotoLbraryChangeObserver](https://developer.apple.com/documentation/photos/phphotolibrarychangeobserver)
- [Apple Developer Documentation/Photos/PHPhotoLbraryChangeObserver/photoLibraryDidChange(_:)](https://developer.apple.com/documentation/photos/phphotolibrarychangeobserver/photolibrarydidchange(_:))

## Close Issues 🔒 (닫을 Issue)
Close #42.
