### PR TITLE
[Fix] API 캐싱 및 버전 비교 오류

### DIFF
--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -44,7 +44,10 @@ class AppVersionManager: ObservableObject {
 
     private func requestRequiredVersion() async throws -> Version {
         guard let url = URL(string: "https://raw.githubusercontent.com/taek0622/Version/refs/heads/main/PiPPl.json") else { return .init(major: 0, minor: 0, patch: 0) }
-        let (data, _) = try await URLSession.shared.data(from: url)
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "GET"
+        urlRequest.cachePolicy = .reloadIgnoringLocalCacheData
+        let (data, _) = try await URLSession.shared.data(for: urlRequest)
         guard let json = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as? [String: Any],
               let requiredVersionString = json["requiredVersion"] as? String,
               let requiredVersion = Version(requiredVersionString)
@@ -56,8 +59,11 @@ class AppVersionManager: ObservableObject {
     private func requestLatestAppStoreVersion() async throws -> Version {
         guard let url = URL(string: "https://itunes.apple.com/lookup?id=\(iTunesID)")
         else { return .init(0, 0, 0) }
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "GET"
+        urlRequest.cachePolicy = .reloadIgnoringLocalCacheData
 
-        let (data, _) = try await URLSession.shared.data(from: url)
+        let (data, _) = try await URLSession.shared.data(for: urlRequest)
         guard let json = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as? [String: Any],
               let results = json["results"] as? [[String: Any]],
               let latestAppStoreVersionString = results[0]["version"] as? String,

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -31,7 +31,7 @@ class AppVersionManager: ObservableObject {
         guard let requireVersion = try? await requestRequiredVersion() else { return . latest }
         guard let latestAppStoreVersion = try? await requestLatestAppStoreVersion() else { return .latest }
 
-        if downloadedAppVersion == latestAppStoreVersion {
+        if downloadedAppVersion >= latestAppStoreVersion {
             return .latest
         } else if requireVersion > downloadedAppVersion || latestAppStoreVersion.major > downloadedAppVersion.major || (latestAppStoreVersion.major == downloadedAppVersion.major && latestAppStoreVersion.minor > downloadedAppVersion.minor + 4) || (latestAppStoreVersion.major == downloadedAppVersion.major && latestAppStoreVersion.minor == downloadedAppVersion.minor && latestAppStoreVersion.patch > downloadedAppVersion.patch + 8) {
             return .required

--- a/PiPPl/Utility/NoticeViewModel.swift
+++ b/PiPPl/Utility/NoticeViewModel.swift
@@ -16,6 +16,7 @@ final class NoticeViewModel: ObservableObject {
         guard let url = URL(string: "https://raw.githubusercontent.com/taek0622/Notice/main/notice.json") else { return }
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "GET"
+        urlRequest.cachePolicy = .reloadIgnoringLocalCacheData
 
         do {
             let (data, _) = try await URLSession.shared.data(for: urlRequest)


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- API를 캐싱해서 업데이트된 정보를 반영하지 못하는 문제를 해결하기 위함
- 버전 비교에서 최신 버전을 갖고 있어도 업데이트가 있다고 보여주는 문제를 해결하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- `URLSession`으로 정보를 요청하는 `requestRequiredVersion()`, `requesetLatestAppStoreVersion()`, `requestNoticeData()` 메서드에 `cachePolicy`를 `.reloadIgnoringLocalCacheData`(local 캐시를 무시하고 항상 네트워크에 접속)으로 설정
- 버전 비교 부분에서 다운로드 버전이 최신 버전과 같으면이 아니라 크거나 같으면으로 변경

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗
- [Apple Developer Documentation/Foundation/URLRequest/cachePolicy](https://developer.apple.com/documentation/foundation/urlrequest/cachepolicy-swift.property)
- [Apple Developer Documentation/Foundation/URLRequest/URLRequest.CachePolicy](https://developer.apple.com/documentation/foundation/urlrequest/cachepolicy-swift.typealias)
- [Apple Developer Documentation/Foundation/NSURLRequest/NSURLRequest.CachePolicy](https://developer.apple.com/documentation/foundation/nsurlrequest/cachepolicy-swift.enum)
- [Apple Developer Documentation/Foundation/NSURLRequest/NSURLRequest.CachePolicy/NSURLRequest.CachePolicy.reloadIgnoringLocalCacheData](https://developer.apple.com/documentation/foundation/nsurlrequest/cachepolicy-swift.enum/reloadignoringlocalcachedata)

## Close Issues 🔒 (닫을 Issue)
Close #50.
