### PR TITLE
[Feature] 동영상 썸네일 캐싱 기능 추가

### DIFF
--- a/PiPPl.xcodeproj/project.pbxproj
+++ b/PiPPl.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		2649A4B12BFF900A007FCC55 /* AppInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2649A4B02BFF900A007FCC55 /* AppInfoView.swift */; };
 		2649A4BD2C066280007FCC55 /* NoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2649A4BC2C066280007FCC55 /* NoticeView.swift */; };
 		264C11102DD045C600E67A5F /* VideoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264C110F2DD045C200E67A5F /* VideoModel.swift */; };
+		264C11122DD0460600E67A5F /* ThumbnailMemoryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264C11112DD045FE00E67A5F /* ThumbnailMemoryCache.swift */; };
 		2683F5512B583E3C00C1CEEB /* LocalVideoLibraryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2683F5502B583E3C00C1CEEB /* LocalVideoLibraryManager.swift */; };
 		26B742AD2BA736A800823338 /* NoticeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B742AC2BA736A800823338 /* NoticeModel.swift */; };
 		26B742AF2BA736C200823338 /* NoticeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B742AE2BA736C200823338 /* NoticeViewModel.swift */; };
@@ -40,6 +41,7 @@
 		2649A4B02BFF900A007FCC55 /* AppInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoView.swift; sourceTree = "<group>"; };
 		2649A4BC2C066280007FCC55 /* NoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeView.swift; sourceTree = "<group>"; };
 		264C110F2DD045C200E67A5F /* VideoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoModel.swift; sourceTree = "<group>"; };
+		264C11112DD045FE00E67A5F /* ThumbnailMemoryCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailMemoryCache.swift; sourceTree = "<group>"; };
 		2683F5502B583E3C00C1CEEB /* LocalVideoLibraryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalVideoLibraryManager.swift; sourceTree = "<group>"; };
 		26B742AC2BA736A800823338 /* NoticeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeModel.swift; sourceTree = "<group>"; };
 		26B742AE2BA736C200823338 /* NoticeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeViewModel.swift; sourceTree = "<group>"; };
@@ -108,6 +110,7 @@
 		263F037D2B598DC400EAC60E /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				264C11112DD045FE00E67A5F /* ThumbnailMemoryCache.swift */,
 				2683F5502B583E3C00C1CEEB /* LocalVideoLibraryManager.swift */,
 				26EBB1952BC728B600C83CA2 /* AppVersionManager.swift */,
 				263F037E2B598DFB00EAC60E /* LocalVideoPlayer.swift */,
@@ -263,6 +266,7 @@
 				26E801D92DB9190500CE20BB /* CustomerServiceMailView.swift in Sources */,
 				26E63A6A2DC939B4000D2C53 /* VersionModel.swift in Sources */,
 				26B742AD2BA736A800823338 /* NoticeModel.swift in Sources */,
+				264C11122DD0460600E67A5F /* ThumbnailMemoryCache.swift in Sources */,
 				26EB7EF02B56AB8100282354 /* NetworkPlayerViewController.swift in Sources */,
 				264C11102DD045C600E67A5F /* VideoModel.swift in Sources */,
 				2683F5512B583E3C00C1CEEB /* LocalVideoLibraryManager.swift in Sources */,

--- a/PiPPl.xcodeproj/project.pbxproj
+++ b/PiPPl.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2649A4AF2BFF8D2B007FCC55 /* NetworkPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2649A4AE2BFF8D2B007FCC55 /* NetworkPlayerView.swift */; };
 		2649A4B12BFF900A007FCC55 /* AppInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2649A4B02BFF900A007FCC55 /* AppInfoView.swift */; };
 		2649A4BD2C066280007FCC55 /* NoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2649A4BC2C066280007FCC55 /* NoticeView.swift */; };
+		264C11102DD045C600E67A5F /* VideoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264C110F2DD045C200E67A5F /* VideoModel.swift */; };
 		2683F5512B583E3C00C1CEEB /* LocalVideoLibraryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2683F5502B583E3C00C1CEEB /* LocalVideoLibraryManager.swift */; };
 		26B742AD2BA736A800823338 /* NoticeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B742AC2BA736A800823338 /* NoticeModel.swift */; };
 		26B742AF2BA736C200823338 /* NoticeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B742AE2BA736C200823338 /* NoticeViewModel.swift */; };
@@ -38,6 +39,7 @@
 		2649A4AE2BFF8D2B007FCC55 /* NetworkPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkPlayerView.swift; sourceTree = "<group>"; };
 		2649A4B02BFF900A007FCC55 /* AppInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoView.swift; sourceTree = "<group>"; };
 		2649A4BC2C066280007FCC55 /* NoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeView.swift; sourceTree = "<group>"; };
+		264C110F2DD045C200E67A5F /* VideoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoModel.swift; sourceTree = "<group>"; };
 		2683F5502B583E3C00C1CEEB /* LocalVideoLibraryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalVideoLibraryManager.swift; sourceTree = "<group>"; };
 		26B742AC2BA736A800823338 /* NoticeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeModel.swift; sourceTree = "<group>"; };
 		26B742AE2BA736C200823338 /* NoticeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeViewModel.swift; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 		26B742AB2BA7368D00823338 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				264C110F2DD045C200E67A5F /* VideoModel.swift */,
 				26E63A692DC939B1000D2C53 /* VersionModel.swift */,
 				26E63A632DC65719000D2C53 /* UpdateState.swift */,
 				26B742AC2BA736A800823338 /* NoticeModel.swift */,
@@ -261,6 +264,7 @@
 				26E63A6A2DC939B4000D2C53 /* VersionModel.swift in Sources */,
 				26B742AD2BA736A800823338 /* NoticeModel.swift in Sources */,
 				26EB7EF02B56AB8100282354 /* NetworkPlayerViewController.swift in Sources */,
+				264C11102DD045C600E67A5F /* VideoModel.swift in Sources */,
 				2683F5512B583E3C00C1CEEB /* LocalVideoLibraryManager.swift in Sources */,
 				263F037F2B598DFB00EAC60E /* LocalVideoPlayer.swift in Sources */,
 				26E63A642DC6571E000D2C53 /* UpdateState.swift in Sources */,

--- a/PiPPl.xcodeproj/project.pbxproj
+++ b/PiPPl.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		2649A4BD2C066280007FCC55 /* NoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2649A4BC2C066280007FCC55 /* NoticeView.swift */; };
 		264C11102DD045C600E67A5F /* VideoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264C110F2DD045C200E67A5F /* VideoModel.swift */; };
 		264C11122DD0460600E67A5F /* ThumbnailMemoryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264C11112DD045FE00E67A5F /* ThumbnailMemoryCache.swift */; };
+		264C11142DD0463700E67A5F /* ThumbnailDiskCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264C11132DD0463100E67A5F /* ThumbnailDiskCache.swift */; };
 		2683F5512B583E3C00C1CEEB /* LocalVideoLibraryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2683F5502B583E3C00C1CEEB /* LocalVideoLibraryManager.swift */; };
 		26B742AD2BA736A800823338 /* NoticeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B742AC2BA736A800823338 /* NoticeModel.swift */; };
 		26B742AF2BA736C200823338 /* NoticeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B742AE2BA736C200823338 /* NoticeViewModel.swift */; };
@@ -42,6 +43,7 @@
 		2649A4BC2C066280007FCC55 /* NoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeView.swift; sourceTree = "<group>"; };
 		264C110F2DD045C200E67A5F /* VideoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoModel.swift; sourceTree = "<group>"; };
 		264C11112DD045FE00E67A5F /* ThumbnailMemoryCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailMemoryCache.swift; sourceTree = "<group>"; };
+		264C11132DD0463100E67A5F /* ThumbnailDiskCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailDiskCache.swift; sourceTree = "<group>"; };
 		2683F5502B583E3C00C1CEEB /* LocalVideoLibraryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalVideoLibraryManager.swift; sourceTree = "<group>"; };
 		26B742AC2BA736A800823338 /* NoticeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeModel.swift; sourceTree = "<group>"; };
 		26B742AE2BA736C200823338 /* NoticeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeViewModel.swift; sourceTree = "<group>"; };
@@ -110,6 +112,7 @@
 		263F037D2B598DC400EAC60E /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				264C11132DD0463100E67A5F /* ThumbnailDiskCache.swift */,
 				264C11112DD045FE00E67A5F /* ThumbnailMemoryCache.swift */,
 				2683F5502B583E3C00C1CEEB /* LocalVideoLibraryManager.swift */,
 				26EBB1952BC728B600C83CA2 /* AppVersionManager.swift */,
@@ -275,6 +278,7 @@
 				26EBB1C82BDFF0EB00C83CA2 /* LocalVideoGalleryView.swift in Sources */,
 				26EBB1962BC728B600C83CA2 /* AppVersionManager.swift in Sources */,
 				2649A4AF2BFF8D2B007FCC55 /* NetworkPlayerView.swift in Sources */,
+				264C11142DD0463700E67A5F /* ThumbnailDiskCache.swift in Sources */,
 				26EBB1C42BDFE88900C83CA2 /* PiPPlApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PiPPl.xcodeproj/project.pbxproj
+++ b/PiPPl.xcodeproj/project.pbxproj
@@ -441,7 +441,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.1;
+				MARKETING_VERSION = 2.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.immeenu.PiPPl;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -475,7 +475,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.1;
+				MARKETING_VERSION = 2.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.immeenu.PiPPl;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/PiPPl/Model/VideoModel.swift
+++ b/PiPPl/Model/VideoModel.swift
@@ -1,0 +1,13 @@
+//
+//  VideoModel.swift
+//  PiPPl
+//
+//  Created by 김민택 on 5/11/25.
+//
+
+import Photos
+
+struct Video: Identifiable {
+    var id: String { asset.localIdentifier }
+    var asset: PHAsset
+}

--- a/PiPPl/Resource/AppText.swift
+++ b/PiPPl/Resource/AppText.swift
@@ -10,6 +10,7 @@ enum AppText {
     // MARK: - Global Text
 
     static let confirm = String(localized: "Confirm")
+    static let cancel = String(localized: "Cancel")
 
     // MARK: - TabBar or SideBar Text
 
@@ -38,6 +39,7 @@ enum AppText {
     static let customerService = String(localized: "CustomerService")
     static let license = String(localized: "License")
     static let versionInfo = String(localized: "AppVersionInfo")
+    static let clearAllCache = String(localized: "clearAllCache")
 
     static let cantSendMailAlertTitle = String(localized: "CantSendMailAlertTitle")
     static let cantSendMailAlertBody = String(localized: "CantSendMailAlertBody")
@@ -65,5 +67,9 @@ enum AppText {
 
     static let latestVersionAlertTitle = String(localized: "LatestVersionAlertTitle")
     static let latestVersionAlertBody = String(localized: "LatestVersionAlertBody")
+
+    // MARK: - Removing Cache Text
+
+    static let clearCacheAlertBody = String(localized: "clearCacheAlertBody")
 
 }

--- a/PiPPl/Resource/Localizable.xcstrings
+++ b/PiPPl/Resource/Localizable.xcstrings
@@ -49,6 +49,22 @@
         }
       }
     },
+    "Cancel" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "취소"
+          }
+        }
+      }
+    },
     "CantSendMailAlertBody" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -83,8 +99,46 @@
         }
       }
     },
+    "clearAllCache" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear Cache"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캐시 데이터 삭제"
+          }
+        }
+      }
+    },
+    "clearCacheAlertBody" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temporary app data will be deleted.\nIt will be automatically recreated if needed."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "앱의 임시 저장 정보를 삭제합니다.\n삭제된 정보는 필요한 경우 자동으로 다시 생성됩니다."
+          }
+        }
+      }
+    },
     "Confirm" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirm"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",

--- a/PiPPl/Resource/Localizable.xcstrings
+++ b/PiPPl/Resource/Localizable.xcstrings
@@ -125,7 +125,7 @@
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "앱의 임시 저장 정보를 삭제합니다.\n삭제된 정보는 필요한 경우 자동으로 다시 생성됩니다."
           }
         }

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -10,63 +10,6 @@ import Photos
 import UIKit
 import Dispatch
 
-class ThumbnailDiskCache {
-
-    static let shared = ThumbnailDiskCache()
-
-    private init() {}
-
-    private let fileManager = FileManager.default
-
-    private var cacheDirectoryURL: URL {
-        let caches = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
-        return caches.appending(path: "ThumbnailCache", directoryHint: .isDirectory)
-    }
-
-    func saveThumbnail(_ image:UIImage, for asset: PHAsset) {
-        let url = fileURL(for: asset)
-
-        if !fileManager.fileExists(atPath: cacheDirectoryURL.path) {
-            try? fileManager.createDirectory(at: cacheDirectoryURL, withIntermediateDirectories: true)
-        }
-
-        if let data = image.jpegData(compressionQuality: 0.8) {
-            try? data.write(to: url)
-        }
-    }
-
-    func loadThumbnail(for asset: PHAsset) -> UIImage? {
-        let url = fileURL(for: asset)
-
-        if !fileManager.fileExists(atPath: cacheDirectoryURL.path) {
-            try? fileManager.createDirectory(at: cacheDirectoryURL, withIntermediateDirectories: true)
-        }
-
-        guard fileManager.fileExists(atPath: url.path),
-              let data = try? Data(contentsOf: url),
-              let image = UIImage(data: data)
-        else { return nil }
-
-        return image
-    }
-
-    func removeThumbnail(for asset: PHAsset) {
-        let url = fileURL(for: asset)
-        try? fileManager.removeItem(at: url)
-    }
-
-    func removeAllThumbnails() {
-        guard fileManager.fileExists(atPath: cacheDirectoryURL.path) else { return }
-        try? fileManager.removeItem(at: cacheDirectoryURL)
-        try? fileManager.createDirectory(at: cacheDirectoryURL, withIntermediateDirectories: true)
-    }
-
-    private func fileURL(for asset: PHAsset) -> URL {
-        let filename = asset.localIdentifier.replacingOccurrences(of: "/", with: "_")
-        return cacheDirectoryURL.appendingPathComponent("\(filename)", conformingTo: .jpeg)
-    }
-
-}
 
 class LocalVideoLibraryManager: NSObject, ObservableObject, PHPhotoLibraryChangeObserver {
 

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -10,11 +10,6 @@ import Photos
 import UIKit
 import Dispatch
 
-struct Video: Identifiable {
-    var id: String { asset.localIdentifier }
-    var asset: PHAsset
-}
-
 class ThumbnailMemoryCache {
 
     static let shared = ThumbnailMemoryCache()

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -15,6 +15,28 @@ struct Video: Identifiable {
     var asset: PHAsset
 }
 
+class ThumbnailMemoryCache {
+
+    static let shared = ThumbnailMemoryCache()
+
+    private init() {}
+
+    private var thumbnailCache = NSCache<NSString, UIImage>()
+
+    func thumbnail(for asset: PHAsset) -> UIImage? {
+        return thumbnailCache.object(forKey: asset.localIdentifier as NSString)
+    }
+
+    func setThumbnail(_ image: UIImage, for asset: PHAsset) {
+        thumbnailCache.setObject(image, forKey: asset.localIdentifier as NSString)
+    }
+
+    func removeThumbnail(for asset: PHAsset) {
+        thumbnailCache.removeObject(forKey: asset.localIdentifier as NSString)
+    }
+
+}
+
 class LocalVideoLibraryManager: NSObject, ObservableObject, PHPhotoLibraryChangeObserver {
 
     @Published var videos = [Video]()

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -5,11 +5,8 @@
 //  Created by 김민택 on 1/18/24.
 //
 
-import Foundation
 import Photos
 import UIKit
-import Dispatch
-
 
 class LocalVideoLibraryManager: NSObject, ObservableObject, PHPhotoLibraryChangeObserver {
 

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -23,14 +23,13 @@ class LocalVideoLibraryManager: NSObject, ObservableObject, PHPhotoLibraryChange
     @Published var isLoading = false
     private var assetFetchResult: PHFetchResult<PHAsset>?
 
-    static let shared = LocalVideoLibraryManager()
     var status: PHAuthorizationStatus {
         get {
             PHPhotoLibrary.authorizationStatus(for: .readWrite)
         }
     }
 
-    override private init() {
+    override init() {
         super.init()
         PHPhotoLibrary.shared().register(self)
     }

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -68,6 +68,11 @@ class ThumbnailDiskCache {
 
     func loadThumbnail(for asset: PHAsset) -> UIImage? {
         let url = fileURL(for: asset)
+
+        if !fileManager.fileExists(atPath: cacheDirectoryURL.path) {
+            try? fileManager.createDirectory(at: cacheDirectoryURL, withIntermediateDirectories: true)
+        }
+
         guard fileManager.fileExists(atPath: url.path),
               let data = try? Data(contentsOf: url),
               let image = UIImage(data: data)

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -208,6 +208,8 @@ class LocalVideoLibraryManager: NSObject, ObservableObject, PHPhotoLibraryChange
             if changes.hasIncrementalChanges {
                 if let removed = changes.removedIndexes {
                     for idx in removed.reversed() {
+                        ThumbnailDiskCache.shared.removeThumbnail(for: self.videos[idx].asset)
+                        ThumbnailMemoryCache.shared.removeThumbnail(for: self.videos[idx].asset)
                         self.videos.remove(at: idx)
                     }
                 }

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -13,7 +13,6 @@ import Dispatch
 struct Video: Identifiable {
     var id: String { asset.localIdentifier }
     var asset: PHAsset
-    var thumbnail: UIImage?
 }
 
 class LocalVideoLibraryManager: NSObject, ObservableObject, PHPhotoLibraryChangeObserver {
@@ -64,8 +63,7 @@ class LocalVideoLibraryManager: NSObject, ObservableObject, PHPhotoLibraryChange
                 let asset = assets.object(at: idx)
 
                 group.addTask {
-                    let thumbnail = await self.requestThumbnail(asset)
-                    return (idx, Video(asset: asset, thumbnail: thumbnail))
+                    return (idx, Video(asset: asset))
                 }
             }
 
@@ -132,8 +130,7 @@ class LocalVideoLibraryManager: NSObject, ObservableObject, PHPhotoLibraryChange
                 if let inserted = changes.insertedIndexes {
                     for idx in inserted {
                         let asset = changes.fetchResultAfterChanges.object(at: idx)
-                        let thumbnail = await self.requestThumbnail(asset)
-                        let video = Video(asset: asset, thumbnail: thumbnail)
+                        let video = Video(asset: asset)
                         self.videos.insert(video, at: idx)
                     }
                 }
@@ -141,8 +138,7 @@ class LocalVideoLibraryManager: NSObject, ObservableObject, PHPhotoLibraryChange
                 if let changed = changes.changedIndexes {
                     for idx in changed {
                         let asset = changes.fetchResultAfterChanges.object(at: idx)
-                        let thumbnail = await self.requestThumbnail(asset)
-                        let video = Video(asset: asset, thumbnail: thumbnail)
+                        let video = Video(asset: asset)
                         self.videos[idx] = video
                     }
                 }

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -11,7 +11,7 @@ import UIKit
 import Dispatch
 
 struct Video: Identifiable {
-    let id = UUID()
+    var id: String { asset.localIdentifier }
     var asset: PHAsset
     var thumbnail: UIImage?
 }

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -10,32 +10,6 @@ import Photos
 import UIKit
 import Dispatch
 
-class ThumbnailMemoryCache {
-
-    static let shared = ThumbnailMemoryCache()
-
-    private init() {}
-
-    private var thumbnailCache = NSCache<NSString, UIImage>()
-
-    func thumbnail(for asset: PHAsset) -> UIImage? {
-        return thumbnailCache.object(forKey: asset.localIdentifier as NSString)
-    }
-
-    func setThumbnail(_ image: UIImage, for asset: PHAsset) {
-        thumbnailCache.setObject(image, forKey: asset.localIdentifier as NSString)
-    }
-
-    func removeThumbnail(for asset: PHAsset) {
-        thumbnailCache.removeObject(forKey: asset.localIdentifier as NSString)
-    }
-
-    func removeAllThumbnails() {
-        thumbnailCache.removeAllObjects()
-    }
-
-}
-
 class ThumbnailDiskCache {
 
     static let shared = ThumbnailDiskCache()

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -35,6 +35,10 @@ class ThumbnailMemoryCache {
         thumbnailCache.removeObject(forKey: asset.localIdentifier as NSString)
     }
 
+    func removeAllThumbnails() {
+        thumbnailCache.removeAllObjects()
+    }
+
 }
 
 class ThumbnailDiskCache {
@@ -75,6 +79,12 @@ class ThumbnailDiskCache {
     func removeThumbnail(for asset: PHAsset) {
         let url = fileURL(for: asset)
         try? fileManager.removeItem(at: url)
+    }
+
+    func removeAllThumbnails() {
+        guard fileManager.fileExists(atPath: cacheDirectoryURL.path) else { return }
+        try? fileManager.removeItem(at: cacheDirectoryURL)
+        try? fileManager.createDirectory(at: cacheDirectoryURL, withIntermediateDirectories: true)
     }
 
     private func fileURL(for asset: PHAsset) -> URL {

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -37,6 +37,53 @@ class ThumbnailMemoryCache {
 
 }
 
+class ThumbnailDiskCache {
+
+    static let shared = ThumbnailDiskCache()
+
+    private init() {}
+
+    private let fileManager = FileManager.default
+
+    private var cacheDirectoryURL: URL {
+        let caches = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        return caches.appending(path: "ThumbnailCache", directoryHint: .isDirectory)
+    }
+
+    func saveThumbnail(_ image:UIImage, for asset: PHAsset) {
+        let url = fileURL(for: asset)
+
+        if !fileManager.fileExists(atPath: cacheDirectoryURL.path) {
+            try? fileManager.createDirectory(at: cacheDirectoryURL, withIntermediateDirectories: true)
+        }
+
+        if let data = image.jpegData(compressionQuality: 0.8) {
+            try? data.write(to: url)
+        }
+    }
+
+    func loadThumbnail(for asset: PHAsset) -> UIImage? {
+        let url = fileURL(for: asset)
+        guard fileManager.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url),
+              let image = UIImage(data: data)
+        else { return nil }
+
+        return image
+    }
+
+    func removeThumbnail(for asset: PHAsset) {
+        let url = fileURL(for: asset)
+        try? fileManager.removeItem(at: url)
+    }
+
+    private func fileURL(for asset: PHAsset) -> URL {
+        let filename = asset.localIdentifier.replacingOccurrences(of: "/", with: "_")
+        return cacheDirectoryURL.appendingPathComponent("\(filename)", conformingTo: .jpeg)
+    }
+
+}
+
 class LocalVideoLibraryManager: NSObject, ObservableObject, PHPhotoLibraryChangeObserver {
 
     @Published var videos = [Video]()

--- a/PiPPl/Utility/LocalVideoLibraryManager.swift
+++ b/PiPPl/Utility/LocalVideoLibraryManager.swift
@@ -156,7 +156,7 @@ class LocalVideoLibraryManager: NSObject, ObservableObject, PHPhotoLibraryChange
         }
     }
 
-    func requestThumbnail(_ asset: PHAsset) async -> UIImage {
+    func requestThumbnail(for asset: PHAsset) async -> UIImage {
         await withCheckedContinuation { continuation in
             Task { @MainActor in
                 let manager = PHImageManager.default()

--- a/PiPPl/Utility/ThumbnailDiskCache.swift
+++ b/PiPPl/Utility/ThumbnailDiskCache.swift
@@ -1,0 +1,67 @@
+//
+//  ThumbnailDiskCache.swift
+//  PiPPl
+//
+//  Created by 김민택 on 5/11/25.
+//
+
+import Photos
+import UIKit
+
+class ThumbnailDiskCache {
+
+    static let shared = ThumbnailDiskCache()
+
+    private init() {}
+
+    private let fileManager = FileManager.default
+
+    private var cacheDirectoryURL: URL {
+        let caches = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        return caches.appending(path: "ThumbnailCache", directoryHint: .isDirectory)
+    }
+
+    func saveThumbnail(_ image:UIImage, for asset: PHAsset) {
+        let url = fileURL(for: asset)
+
+        if !fileManager.fileExists(atPath: cacheDirectoryURL.path) {
+            try? fileManager.createDirectory(at: cacheDirectoryURL, withIntermediateDirectories: true)
+        }
+
+        if let data = image.jpegData(compressionQuality: 0.8) {
+            try? data.write(to: url)
+        }
+    }
+
+    func loadThumbnail(for asset: PHAsset) -> UIImage? {
+        let url = fileURL(for: asset)
+
+        if !fileManager.fileExists(atPath: cacheDirectoryURL.path) {
+            try? fileManager.createDirectory(at: cacheDirectoryURL, withIntermediateDirectories: true)
+        }
+
+        guard fileManager.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url),
+              let image = UIImage(data: data)
+        else { return nil }
+
+        return image
+    }
+
+    func removeThumbnail(for asset: PHAsset) {
+        let url = fileURL(for: asset)
+        try? fileManager.removeItem(at: url)
+    }
+
+    func removeAllThumbnails() {
+        guard fileManager.fileExists(atPath: cacheDirectoryURL.path) else { return }
+        try? fileManager.removeItem(at: cacheDirectoryURL)
+        try? fileManager.createDirectory(at: cacheDirectoryURL, withIntermediateDirectories: true)
+    }
+
+    private func fileURL(for asset: PHAsset) -> URL {
+        let filename = asset.localIdentifier.replacingOccurrences(of: "/", with: "_")
+        return cacheDirectoryURL.appendingPathComponent("\(filename)", conformingTo: .jpeg)
+    }
+
+}

--- a/PiPPl/Utility/ThumbnailMemoryCache.swift
+++ b/PiPPl/Utility/ThumbnailMemoryCache.swift
@@ -1,0 +1,35 @@
+//
+//  ThumbnailMemoryCache.swift
+//  PiPPl
+//
+//  Created by 김민택 on 5/11/25.
+//
+
+import Photos
+import UIKit
+
+class ThumbnailMemoryCache {
+
+    static let shared = ThumbnailMemoryCache()
+
+    private init() {}
+
+    private var thumbnailCache = NSCache<NSString, UIImage>()
+
+    func thumbnail(for asset: PHAsset) -> UIImage? {
+        return thumbnailCache.object(forKey: asset.localIdentifier as NSString)
+    }
+
+    func setThumbnail(_ image: UIImage, for asset: PHAsset) {
+        thumbnailCache.setObject(image, forKey: asset.localIdentifier as NSString)
+    }
+
+    func removeThumbnail(for asset: PHAsset) {
+        thumbnailCache.removeObject(forKey: asset.localIdentifier as NSString)
+    }
+
+    func removeAllThumbnails() {
+        thumbnailCache.removeAllObjects()
+    }
+
+}

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -26,6 +26,7 @@ struct AppInfoView: View {
     @State private var url = URL(string: "https://www.google.com")!
     @State private var isMailSend = false
     @State private var isUnavailableMail = false
+    @State private var isClearCache: Bool = false
 
     var body: some View {
         List {
@@ -66,6 +67,9 @@ struct AppInfoView: View {
                         .font(.system(size: 16))
                 }
             }
+            Button(AppText.clearAllCache, role: .destructive) {
+                isClearCache = true
+            }
         }
         .fullScreenCover(isPresented: $isOpenSafariView, content: {
             SafariView(url: url)
@@ -101,6 +105,16 @@ struct AppInfoView: View {
             }
         } message: {
             Text(updateState.updateAlertBody)
+        }
+        .alert(AppText.clearAllCache, isPresented: $isClearCache) {
+            Button(AppText.confirm, role: .destructive) {
+                ThumbnailDiskCache.shared.removeAllThumbnails()
+                ThumbnailMemoryCache.shared.removeAllThumbnails()
+            }
+
+            Button(AppText.cancel, role: .cancel) {}
+        } message: {
+            Text(AppText.clearCacheAlertBody)
         }
     }
 }

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -97,7 +97,7 @@ struct AppInfoView: View {
             }
 
             if updateState == .recommended || updateState == .available {
-                Button(AppText.updateAvailableAlertPostponeAction) {}
+                Button(AppText.updateAvailableAlertPostponeAction, role: .cancel) {}
             }
         } message: {
             Text(updateState.updateAlertBody)

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -121,7 +121,7 @@ struct LocalVideoGalleryView: View {
             }
 
             if updateState == .recommended || updateState == .available {
-                Button(AppText.updateAvailableAlertPostponeAction) {}
+                Button(AppText.updateAvailableAlertPostponeAction, role: .cancel) {}
             }
         } message: {
             Text(updateState.updateAlertBody)

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -67,8 +67,7 @@ struct LocalVideoGalleryView: View {
                                     .toolbar(.hidden, for: .tabBar)
                             } label: {
                                 ZStack(alignment: .bottomTrailing) {
-                                    Image(uiImage: video.thumbnail ?? UIImage(ciImage: CIImage(color: .gray)))
-                                        .resizable()
+                                    AssetImage(asset: video.asset, libraryManager: libraryManager)
                                         .frame(height: UIScreen.main.bounds.width/rowItemCount)
 
                                     let duration = Int(video.asset.duration)
@@ -158,6 +157,26 @@ struct LocalVideoGalleryView: View {
 
                     if updateAlertCount == 3 { updateAlertCount = 0 }
                 }
+            }
+        }
+    }
+}
+
+struct AssetImage: View {
+    let asset: PHAsset
+    @State private var image: UIImage?
+    @ObservedObject var libraryManager: LocalVideoLibraryManager
+
+    var body: some View {
+        Group {
+            if let image = image {
+                Image(uiImage: image)
+                    .resizable()
+            } else {
+                ProgressView()
+                    .task {
+                        image = await libraryManager.thumbnail(for: asset)
+                    }
             }
         }
     }

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -13,7 +13,7 @@ struct LocalVideoGalleryView: View {
     @State private var isPermissionAccessable = false
     @State private var updateState: UpdateState = .latest
     @State private var isUpdateAlertOpen = false
-    @StateObject private var libraryManager = LocalVideoLibraryManager.shared
+    @StateObject private var libraryManager = LocalVideoLibraryManager()
     @EnvironmentObject var appVersionManager: AppVersionManager
     @Environment(\.colorScheme) private var colorScheme
     var rowItemCount: Double {

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![Platforms-iPadOS](https://img.shields.io/badge/iPadOS-16.0+-skyblue)
 
 ## 다운로드
-<a href="https://apps.apple.com/kr/app/pippl/id6479563734">![Latest_Version](https://img.shields.io/badge/version-2.3.1-green)<br>
+<a href="https://apps.apple.com/kr/app/pippl/id6479563734">![Latest_Version](https://img.shields.io/badge/version-2.5.0-green)<br>
 <img src="https://github.com/taek0622/PiPPl/assets/81027256/c69ed780-ff4a-42fd-9ba4-a8d643f78454"></a>
 
 ## iOS 스크린샷


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 동영상의 썸네일 관련 기능을 추가하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 썸네일을 메모리 캐시에 저장하기 위한 `ThumbnailMemoryCache` 클래스 추가
- 썸네일을 디스크 캐시에 저장하기 위한 `ThumbnailDiskCache` 클래스 추가
- `Video` 모델 별도 파일로 분리
- `Video` 모델에서 `thumbnail` 프로퍼티 삭제
- `Video` 모델의 `id`를 모델 생성시 랜덤한 `UUID` 부여 방식에서 각각의 `PHAsset`의 고유한 `identifier` 사용 방식으로 변경
    - Cache의 키로 사용하기 위함
- `LocalVideoLibraryManager`에 썸네일을 적절하게 불러오기 위한 `thumbnail` 메서드 추가
    - 메모리 캐시에 썸네일이 있다면 메모리 캐시의 썸네일 사용
    - 메모리 캐시에 썸네일이 없고, 디스크 캐시에 썸네일이 있다면 디스크 캐시의 썸네일을 메모리 캐시에 불러와서 사용
    - 메모리 캐시와 디스크 캐시 모두 썸네일이 없다면, `PHAsset`에서 썸네일을 불러와 디스크 캐시와 메모리 캐시에 불러와서 사용
- `AppInfoView`에 모든 캐시 삭제 기능 추가
- 캐시 관련 문자열 및 번역 추가
- 일부 버튼을 용도에 맞는 UI로 변경

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗
- [Apple Developer Documentation/Foundation/NSCache](https://developer.apple.com/documentation/foundation/nscache)
- [Apple Developer Documentation/Foundation/FileManager](https://developer.apple.com/documentation/foundation/filemanager)
- [Apple Developer Documentation/Photos/PHObject/localIdentifier](https://developer.apple.com/documentation/photos/phobject/localidentifier)

## Close Issues 🔒 (닫을 Issue)
Close #52.
