### PR TITLE
[Chore] 네비게이션 개선

### DIFF
--- a/PiPPl.xcodeproj/project.pbxproj
+++ b/PiPPl.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		264C11102DD045C600E67A5F /* VideoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264C110F2DD045C200E67A5F /* VideoModel.swift */; };
 		264C11122DD0460600E67A5F /* ThumbnailMemoryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264C11112DD045FE00E67A5F /* ThumbnailMemoryCache.swift */; };
 		264C11142DD0463700E67A5F /* ThumbnailDiskCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264C11132DD0463100E67A5F /* ThumbnailDiskCache.swift */; };
+		264C11342DD2680C00E67A5F /* ViewSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264C11332DD2680800E67A5F /* ViewSelection.swift */; };
 		2683F5512B583E3C00C1CEEB /* LocalVideoLibraryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2683F5502B583E3C00C1CEEB /* LocalVideoLibraryManager.swift */; };
 		26B742AD2BA736A800823338 /* NoticeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B742AC2BA736A800823338 /* NoticeModel.swift */; };
 		26B742AF2BA736C200823338 /* NoticeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B742AE2BA736C200823338 /* NoticeViewModel.swift */; };
@@ -44,6 +45,7 @@
 		264C110F2DD045C200E67A5F /* VideoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoModel.swift; sourceTree = "<group>"; };
 		264C11112DD045FE00E67A5F /* ThumbnailMemoryCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailMemoryCache.swift; sourceTree = "<group>"; };
 		264C11132DD0463100E67A5F /* ThumbnailDiskCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailDiskCache.swift; sourceTree = "<group>"; };
+		264C11332DD2680800E67A5F /* ViewSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewSelection.swift; sourceTree = "<group>"; };
 		2683F5502B583E3C00C1CEEB /* LocalVideoLibraryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalVideoLibraryManager.swift; sourceTree = "<group>"; };
 		26B742AC2BA736A800823338 /* NoticeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeModel.swift; sourceTree = "<group>"; };
 		26B742AE2BA736C200823338 /* NoticeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeViewModel.swift; sourceTree = "<group>"; };
@@ -125,6 +127,7 @@
 		26B742AB2BA7368D00823338 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				264C11332DD2680800E67A5F /* ViewSelection.swift */,
 				264C110F2DD045C200E67A5F /* VideoModel.swift */,
 				26E63A692DC939B1000D2C53 /* VersionModel.swift */,
 				26E63A632DC65719000D2C53 /* UpdateState.swift */,
@@ -280,6 +283,7 @@
 				2649A4AF2BFF8D2B007FCC55 /* NetworkPlayerView.swift in Sources */,
 				264C11142DD0463700E67A5F /* ThumbnailDiskCache.swift in Sources */,
 				26EBB1C42BDFE88900C83CA2 /* PiPPlApp.swift in Sources */,
+				264C11342DD2680C00E67A5F /* ViewSelection.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PiPPl/Model/VideoModel.swift
+++ b/PiPPl/Model/VideoModel.swift
@@ -7,7 +7,7 @@
 
 import Photos
 
-struct Video: Identifiable {
+struct Video: Identifiable, Hashable {
     var id: String { asset.localIdentifier }
     var asset: PHAsset
 }

--- a/PiPPl/Model/ViewSelection.swift
+++ b/PiPPl/Model/ViewSelection.swift
@@ -1,0 +1,21 @@
+//
+//  ViewSelection.swift
+//  PiPPl
+//
+//  Created by 김민택 on 5/13/25.
+//
+
+enum ViewSelection {
+    case localVideo
+    case networkVideo
+    case appInfo
+}
+
+enum LocalViewSelection: Hashable {
+    case playView(Video)
+}
+
+enum AppInfoViewSelection: Hashable {
+    case noticeView
+    case licenseView
+}

--- a/PiPPl/Utility/AppVersionManager.swift
+++ b/PiPPl/Utility/AppVersionManager.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 class AppVersionManager: ObservableObject {
+
     @Published var updateState = UpdateState.latest
     @Published var isUpdateAlertOpened = false
 
@@ -25,6 +26,14 @@ class AppVersionManager: ObservableObject {
            let versions = Version(downloadedVersionString) {
             self.downloadedAppVersion = versions
         } else { self.downloadedAppVersion = .init(0, 0, 0) }
+
+        Task {
+            let newState = await checkNewUpdate()
+
+            await MainActor.run {
+                self.updateState = newState
+            }
+        }
     }
 
     func checkNewUpdate() async -> UpdateState {

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -132,6 +132,6 @@ struct SafariView: UIViewControllerRepresentable {
 
 #Preview {
     NavigationStack {
-        AppInfoView()
+        AppInfoView(appInfoPath: .constant(NavigationPath()))
     }
 }

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -117,6 +117,14 @@ struct AppInfoView: View {
         } message: {
             Text(AppText.clearCacheAlertBody)
         }
+        .navigationDestination(for: AppInfoViewSelection.self) { view in
+            switch view {
+                case .noticeView:
+                    NoticeView()
+                case .licenseView:
+                    EmptyView()
+            }
+        }
     }
 }
 

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct AppInfoView: View {
     @EnvironmentObject var appVersionManager: AppVersionManager
+    @Binding var appInfoPath: NavigationPath
     @State private var isOpenSafariView = false
     @State private var isOldVersion = false
     @State private var isSelectAppVersion = false
@@ -18,7 +19,6 @@ struct AppInfoView: View {
     @State private var isMailSend = false
     @State private var isUnavailableMail = false
     @State private var isClearCache: Bool = false
-    @Binding var appInfoPath: NavigationPath
 
     var body: some View {
         List {

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -22,7 +22,6 @@ struct AppInfoView: View {
     @State private var isOpenSafariView = false
     @State private var isOldVersion = false
     @State private var isSelectAppVersion = false
-    @State private var updateState: UpdateState = .latest
     @State private var url = URL(string: "https://www.google.com")!
     @State private var isMailSend = false
     @State private var isUnavailableMail = false
@@ -51,9 +50,9 @@ struct AppInfoView: View {
             }
             Button {
                 Task {
-                    updateState = await appVersionManager.checkNewUpdate()
+//                    appVersionManager.updateState = await appVersionManager.checkNewUpdate()
 
-                    if updateState == .latest {
+                    if appVersionManager.updateState == .latest {
                         isSelectAppVersion = true
                     } else {
                         isOldVersion = true
@@ -92,8 +91,8 @@ struct AppInfoView: View {
         } message: {
             Text(AppText.latestVersionAlertBody)
         }
-        .alert(updateState.updateAlertTitle, isPresented: $isOldVersion) {
-            Button(updateState.updateAlertPrimaryAction) {
+        .alert(appVersionManager.updateState.updateAlertTitle, isPresented: $isOldVersion) {
+            Button(appVersionManager.updateState.updateAlertPrimaryAction) {
                 let appStoreOpenURL = "itms-apps://itunes.apple.com/app/apple-store/\(appVersionManager.iTunesID)"
                 guard let url = URL(string: appStoreOpenURL) else { return }
                 if UIApplication.shared.canOpenURL(url) {
@@ -101,11 +100,11 @@ struct AppInfoView: View {
                 }
             }
 
-            if updateState == .recommended || updateState == .available {
+            if appVersionManager.updateState == .recommended || appVersionManager.updateState == .available {
                 Button(AppText.updateAvailableAlertPostponeAction, role: .cancel) {}
             }
         } message: {
-            Text(updateState.updateAlertBody)
+            Text(appVersionManager.updateState.updateAlertBody)
         }
         .alert(AppText.clearAllCache, isPresented: $isClearCache) {
             Button(AppText.confirm, role: .destructive) {

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -50,8 +50,6 @@ struct AppInfoView: View {
             }
             Button {
                 Task {
-//                    appVersionManager.updateState = await appVersionManager.checkNewUpdate()
-
                     if appVersionManager.updateState == .latest {
                         isSelectAppVersion = true
                     } else {

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -10,14 +10,6 @@ import SafariServices
 import SwiftUI
 
 struct AppInfoView: View {
-    enum AppInfoAction {
-        case none
-        case developerInfo
-        case customerService
-        case license
-        case versionInfo
-    }
-
     @EnvironmentObject var appVersionManager: AppVersionManager
     @State private var isOpenSafariView = false
     @State private var isOldVersion = false

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -31,8 +31,8 @@ struct AppInfoView: View {
 
     var body: some View {
         List {
-            NavigationLink(AppText.notice) {
-                NoticeView()
+            Button(AppText.notice) {
+                appInfoPath.append(AppInfoViewSelection.noticeView)
             }
             Button(AppText.developerInfo) {
                 url = URL(string: "https://github.com/taek0622")!

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -27,6 +27,7 @@ struct AppInfoView: View {
     @State private var isMailSend = false
     @State private var isUnavailableMail = false
     @State private var isClearCache: Bool = false
+    @Binding var appInfoPath: NavigationPath
 
     var body: some View {
         List {

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -30,8 +30,15 @@ struct AppInfoView: View {
 
     var body: some View {
         List {
-            Button(AppText.notice) {
+            Button {
                 appInfoPath.append(AppInfoViewSelection.noticeView)
+            } label: {
+                HStack {
+                    Text(AppText.notice)
+                    Spacer()
+                    Image(systemName: "chevron.forward")
+                        .fontWeight(.medium)
+                }
             }
             Button(AppText.developerInfo) {
                 url = URL(string: "https://github.com/taek0622")!

--- a/PiPPl/View/AppInfo/NoticeView.swift
+++ b/PiPPl/View/AppInfo/NoticeView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct NoticeView: View {
-
     @StateObject var noticeViewModel = NoticeViewModel()
 
     var body: some View {

--- a/PiPPl/View/ContentView.swift
+++ b/PiPPl/View/ContentView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct ContentView: View {
-
     @State private var selectedView: ViewSelection = .localVideo
     @State private var localPath = NavigationPath()
     @State private var appInfoPath = NavigationPath()

--- a/PiPPl/View/ContentView.swift
+++ b/PiPPl/View/ContentView.swift
@@ -23,10 +23,10 @@ struct ContentView: View {
         case appInfo
     }
 
-    @StateObject var localVideoLibraryManager = LocalVideoLibraryManager()
     @State private var selectedView: ViewSelection = .localVideo
     @State private var localPath = NavigationPath()
     @State private var appInfoPath = NavigationPath()
+    @StateObject var localVideoLibraryManager = LocalVideoLibraryManager()
 
     var body: some View {
         if UIDevice.current.userInterfaceIdiom == .phone {

--- a/PiPPl/View/ContentView.swift
+++ b/PiPPl/View/ContentView.swift
@@ -18,20 +18,25 @@ struct ContentView: View {
 
     var body: some View {
         if UIDevice.current.userInterfaceIdiom == .phone {
-            TabView {
+            TabView(selection: $selectedView) {
                 NavigationStack {
                     LocalVideoGalleryView(localPath: $localPath, localVideoLibraryManager: localVideoLibraryManager)
                         .navigationTitle(AppText.localVideo)
                         .navigationBarTitleDisplayMode(.inline)
                 }
                 .tabItem { Label(AppText.localVideo, systemImage: "play.square") }
+                .tag(ViewSelection.localVideo)
+
                 NetworkPlayerView()
                     .tabItem { Label(AppText.networkVideo, systemImage: "globe") }
+                    .tag(ViewSelection.networkVideo)
+
                 NavigationStack {
                     AppInfoView(appInfoPath: $appInfoPath)
                         .navigationTitle(AppText.appInfo)
                 }
                 .tabItem { Label(AppText.appInfo, systemImage: "info.circle") }
+                .tag(ViewSelection.appInfo)
             }
         } else if UIDevice.current.userInterfaceIdiom == .pad {
             NavigationSplitView {

--- a/PiPPl/View/ContentView.swift
+++ b/PiPPl/View/ContentView.swift
@@ -25,6 +25,8 @@ struct ContentView: View {
 
     @StateObject var localVideoLibraryManager = LocalVideoLibraryManager()
     @State private var selectedView: ViewSelection = .localVideo
+    @State private var localPath = NavigationPath()
+    @State private var appInfoPath = NavigationPath()
 
     var body: some View {
         if UIDevice.current.userInterfaceIdiom == .phone {

--- a/PiPPl/View/ContentView.swift
+++ b/PiPPl/View/ContentView.swift
@@ -8,9 +8,6 @@
 import SwiftUI
 
 struct ContentView: View {
-    let localVideoGalleryView = LocalVideoGalleryView()
-    let networkPlayerView = NetworkPlayerView()
-    let appInfoView = AppInfoView()
     enum ViewSelection {
         case localVideo
         case networkVideo
@@ -23,15 +20,15 @@ struct ContentView: View {
         if UIDevice.current.userInterfaceIdiom == .phone {
             TabView {
                 NavigationStack {
-                    localVideoGalleryView
+                    LocalVideoGalleryView(localPath: $localPath, localVideoLibraryManager: localVideoLibraryManager)
                         .navigationTitle(AppText.localVideo)
                         .navigationBarTitleDisplayMode(.inline)
                 }
                 .tabItem { Label(AppText.localVideo, systemImage: "play.square") }
-                networkPlayerView
+                NetworkPlayerView()
                     .tabItem { Label(AppText.networkVideo, systemImage: "globe") }
                 NavigationStack {
-                    appInfoView
+                    AppInfoView(appInfoPath: $appInfoPath)
                         .navigationTitle(AppText.appInfo)
                 }
                 .tabItem { Label(AppText.appInfo, systemImage: "info.circle") }

--- a/PiPPl/View/ContentView.swift
+++ b/PiPPl/View/ContentView.swift
@@ -23,6 +23,7 @@ struct ContentView: View {
         case appInfo
     }
 
+    @StateObject var localVideoLibraryManager = LocalVideoLibraryManager()
     @State private var selectedView: ViewSelection = .localVideo
 
     var body: some View {

--- a/PiPPl/View/ContentView.swift
+++ b/PiPPl/View/ContentView.swift
@@ -31,7 +31,7 @@ struct ContentView: View {
     var body: some View {
         if UIDevice.current.userInterfaceIdiom == .phone {
             TabView(selection: $selectedView) {
-                NavigationStack {
+                NavigationStack(path: $localPath) {
                     LocalVideoGalleryView(localPath: $localPath, localVideoLibraryManager: localVideoLibraryManager)
                         .navigationTitle(AppText.localVideo)
                         .navigationBarTitleDisplayMode(.inline)
@@ -43,7 +43,7 @@ struct ContentView: View {
                     .tabItem { Label(AppText.networkVideo, systemImage: "globe") }
                     .tag(ViewSelection.networkVideo)
 
-                NavigationStack {
+                NavigationStack(path: $appInfoPath) {
                     AppInfoView(appInfoPath: $appInfoPath)
                         .navigationTitle(AppText.appInfo)
                         .navigationBarTitleDisplayMode(.inline)

--- a/PiPPl/View/ContentView.swift
+++ b/PiPPl/View/ContentView.swift
@@ -11,6 +11,13 @@ struct ContentView: View {
     let localVideoGalleryView = LocalVideoGalleryView()
     let networkPlayerView = NetworkPlayerView()
     let appInfoView = AppInfoView()
+    enum ViewSelection {
+        case localVideo
+        case networkVideo
+        case appInfo
+    }
+
+    @State private var selectedView: ViewSelection = .localVideo
 
     var body: some View {
         if UIDevice.current.userInterfaceIdiom == .phone {

--- a/PiPPl/View/ContentView.swift
+++ b/PiPPl/View/ContentView.swift
@@ -7,6 +7,15 @@
 
 import SwiftUI
 
+enum LocalViewSelection: Hashable {
+    case playView(Video)
+}
+
+enum AppInfoViewSelection: Hashable {
+    case noticeView
+    case licenseView
+}
+
 struct ContentView: View {
     enum ViewSelection {
         case localVideo

--- a/PiPPl/View/ContentView.swift
+++ b/PiPPl/View/ContentView.swift
@@ -43,6 +43,7 @@ struct ContentView: View {
                 NavigationStack {
                     AppInfoView(appInfoPath: $appInfoPath)
                         .navigationTitle(AppText.appInfo)
+                        .navigationBarTitleDisplayMode(.inline)
                 }
                 .tabItem { Label(AppText.appInfo, systemImage: "info.circle") }
                 .tag(ViewSelection.appInfo)

--- a/PiPPl/View/ContentView.swift
+++ b/PiPPl/View/ContentView.swift
@@ -7,21 +7,7 @@
 
 import SwiftUI
 
-enum LocalViewSelection: Hashable {
-    case playView(Video)
-}
-
-enum AppInfoViewSelection: Hashable {
-    case noticeView
-    case licenseView
-}
-
 struct ContentView: View {
-    enum ViewSelection {
-        case localVideo
-        case networkVideo
-        case appInfo
-    }
 
     @State private var selectedView: ViewSelection = .localVideo
     @State private var localPath = NavigationPath()

--- a/PiPPl/View/ContentView.swift
+++ b/PiPPl/View/ContentView.swift
@@ -41,33 +41,48 @@ struct ContentView: View {
         } else if UIDevice.current.userInterfaceIdiom == .pad {
             NavigationSplitView {
                 List {
-                    NavigationLink {
-                        NavigationStack {
-                            localVideoGalleryView
-                                .navigationTitle(AppText.localVideo)
-                        }
+                    Button {
+                        selectedView = .localVideo
                     } label: {
                         Label(AppText.localVideo, systemImage: "play.square")
                     }
-                    NavigationLink {
-                        networkPlayerView
+
+                    Button {
+                        selectedView = .networkVideo
                     } label: {
                         Label(AppText.networkVideo, systemImage: "globe")
                     }
-                    NavigationLink {
-                        NavigationStack {
-                            appInfoView
-                                .navigationTitle(AppText.appInfo)
-                        }
+
+                    Button {
+                        selectedView = .appInfo
                     } label: {
                         Label(AppText.appInfo, systemImage: "info.circle")
                     }
                 }
                 .listStyle(.plain)
             } detail: {
-                NavigationStack {
-                    localVideoGalleryView
-                        .navigationTitle(AppText.localVideo)
+                VStack {
+                    switch selectedView {
+                        case .localVideo:
+                            NavigationStack(path: $localPath) {
+                                LocalVideoGalleryView(localPath: $localPath, localVideoLibraryManager: localVideoLibraryManager)
+                                    .navigationTitle(AppText.localVideo)
+                                    .navigationBarTitleDisplayMode(.inline)
+                            }
+                        case .networkVideo:
+                            NavigationStack {
+                                NetworkPlayerView()
+                                    .navigationTitle(AppText.networkVideo)
+                                    .toolbar(.hidden)
+                            }
+                        case .appInfo:
+                            NavigationStack(path: $appInfoPath) {
+                                AppInfoView(appInfoPath: $appInfoPath)
+                                    .navigationTitle(AppText.appInfo)
+                                    .navigationBarTitleDisplayMode(.inline)
+                            }
+                    }
+                }
                 }
             }
         } else {

--- a/PiPPl/View/ContentView.swift
+++ b/PiPPl/View/ContentView.swift
@@ -96,6 +96,16 @@ struct ContentView: View {
                             }
                     }
                 }
+                .onChange(of: selectedView) { value in
+                    switch value {
+                        case .localVideo:
+                            appInfoPath = .init()
+                        case .networkVideo:
+                            localPath = .init()
+                            appInfoPath = .init()
+                        case .appInfo:
+                            localPath = .init()
+                    }
                 }
             }
         } else {

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -141,8 +141,6 @@ struct LocalVideoGalleryView: View {
             }
 
             Task {
-//                appVersionManager.updateState = await appVersionManager.checkNewUpdate()
-
                 if appVersionManager.updateState == .required && !appVersionManager.isUpdateAlertOpened {
                     isUpdateAlertOpen = true
                     appVersionManager.isUpdateAlertOpened = true

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -13,6 +13,7 @@ struct LocalVideoGalleryView: View {
     @State private var isPermissionAccessable = false
     @State private var updateState: UpdateState = .latest
     @State private var isUpdateAlertOpen = false
+    @Binding var localPath: NavigationPath
     @ObservedObject var localVideoLibraryManager: LocalVideoLibraryManager
     @EnvironmentObject var appVersionManager: AppVersionManager
     @Environment(\.colorScheme) private var colorScheme

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct LocalVideoGalleryView: View {
     @AppStorage("updateAlertCount") var updateAlertCount: Int = 0
     @State private var isPermissionAccessable = false
-    @State private var updateState: UpdateState = .latest
     @State private var isUpdateAlertOpen = false
     @Binding var localPath: NavigationPath
     @ObservedObject var localVideoLibraryManager: LocalVideoLibraryManager
@@ -101,18 +100,18 @@ struct LocalVideoGalleryView: View {
             }
         }
         .toolbar {
-            if updateState != .latest {
+            if appVersionManager.updateState != .latest {
                 Button {
                     isUpdateAlertOpen = true
                 } label: {
                     Image(systemName: "arrow.up.square.fill")
-                        .foregroundStyle(updateState.updateNotificationColor)
+                        .foregroundStyle(appVersionManager.updateState.updateNotificationColor)
                 }
 
             }
         }
-        .alert(updateState.updateAlertTitle, isPresented: $isUpdateAlertOpen) {
-            Button(updateState.updateAlertPrimaryAction) {
+        .alert(appVersionManager.updateState.updateAlertTitle, isPresented: $isUpdateAlertOpen) {
+            Button(appVersionManager.updateState.updateAlertPrimaryAction) {
                 let appStoreOpenURL = "itms-apps://itunes.apple.com/app/apple-store/\(appVersionManager.iTunesID)"
                 guard let url = URL(string: appStoreOpenURL) else { return }
                 if UIApplication.shared.canOpenURL(url) {
@@ -120,11 +119,11 @@ struct LocalVideoGalleryView: View {
                 }
             }
 
-            if updateState == .recommended || updateState == .available {
+            if appVersionManager.updateState == .recommended || appVersionManager.updateState == .available {
                 Button(AppText.updateAvailableAlertPostponeAction, role: .cancel) {}
             }
         } message: {
-            Text(updateState.updateAlertBody)
+            Text(appVersionManager.updateState.updateAlertBody)
         }
         .onAppear {
             switch localVideoLibraryManager.status {
@@ -142,12 +141,12 @@ struct LocalVideoGalleryView: View {
             }
 
             Task {
-                updateState = await appVersionManager.checkNewUpdate()
+//                appVersionManager.updateState = await appVersionManager.checkNewUpdate()
 
-                if updateState == .required && !appVersionManager.isUpdateAlertOpened {
+                if appVersionManager.updateState == .required && !appVersionManager.isUpdateAlertOpened {
                     isUpdateAlertOpen = true
                     appVersionManager.isUpdateAlertOpened = true
-                } else if updateState == .recommended && !appVersionManager.isUpdateAlertOpened {
+                } else if appVersionManager.updateState == .recommended && !appVersionManager.isUpdateAlertOpened {
                     if updateAlertCount == 0 {
                         isUpdateAlertOpen = true
                         appVersionManager.isUpdateAlertOpened = true

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -13,7 +13,7 @@ struct LocalVideoGalleryView: View {
     @State private var isPermissionAccessable = false
     @State private var updateState: UpdateState = .latest
     @State private var isUpdateAlertOpen = false
-    @StateObject private var localVideoLibraryManager = LocalVideoLibraryManager()
+    @ObservedObject var localVideoLibraryManager: LocalVideoLibraryManager
     @EnvironmentObject var appVersionManager: AppVersionManager
     @Environment(\.colorScheme) private var colorScheme
     var rowItemCount: Double {

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -9,13 +9,14 @@ import Photos
 import SwiftUI
 
 struct LocalVideoGalleryView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @EnvironmentObject var appVersionManager: AppVersionManager
     @AppStorage("updateAlertCount") var updateAlertCount: Int = 0
+    @Binding var localPath: NavigationPath
     @State private var isPermissionAccessable = false
     @State private var isUpdateAlertOpen = false
-    @Binding var localPath: NavigationPath
     @ObservedObject var localVideoLibraryManager: LocalVideoLibraryManager
-    @EnvironmentObject var appVersionManager: AppVersionManager
-    @Environment(\.colorScheme) private var colorScheme
+
     var rowItemCount: Double {
         if UIDevice.current.userInterfaceIdiom == .phone {
             if UIDevice.current.orientation == .portrait {

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -185,6 +185,6 @@ struct AssetImage: View {
 
 #Preview {
     NavigationView {
-        LocalVideoGalleryView()
+        LocalVideoGalleryView(localPath: .constant(NavigationPath()), localVideoLibraryManager: LocalVideoLibraryManager())
     }
 }

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -159,6 +159,13 @@ struct LocalVideoGalleryView: View {
                 }
             }
         }
+        .navigationDestination(for: LocalViewSelection.self) { view in
+            switch view {
+                case .playView(let video):
+                    LocalVideoPlayView(asset: video.asset)
+                        .toolbar(.hidden, for: .tabBar)
+            }
+        }
     }
 }
 

--- a/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoGalleryView.swift
@@ -63,9 +63,8 @@ struct LocalVideoGalleryView: View {
                 ScrollView {
                     LazyVGrid(columns: Array(repeating: GridItem(.fixed(UIScreen.main.bounds.width/rowItemCount), spacing: 1), count: Int(rowItemCount)), spacing: 1) {
                         ForEach(localVideoLibraryManager.videos, id: \.id) { video in
-                            NavigationLink {
-                                LocalVideoPlayView(asset: video.asset)
-                                    .toolbar(.hidden, for: .tabBar)
+                            Button {
+                                localPath.append(LocalViewSelection.playView(video))
                             } label: {
                                 ZStack(alignment: .bottomTrailing) {
                                     AssetImage(asset: video.asset, localVideoLibraryManager: localVideoLibraryManager)

--- a/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
@@ -10,9 +10,10 @@ import Photos
 import SwiftUI
 
 struct LocalVideoPlayView: View {
-    @StateObject private var localVideoPlayer = LocalVideoPlayer()
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.isPresented) var isPresented
+    @StateObject private var localVideoPlayer = LocalVideoPlayer()
+
     var asset: PHAsset
 
     var body: some View {

--- a/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
+++ b/PiPPl/View/LocalVideo/LocalVideoPlayView.swift
@@ -37,9 +37,9 @@ struct LocalVideoPlayView: View {
         .toolbar(content: {
             ToolbarItem(placement: .principal) {
                 VStack {
-                    Text(asset.creationDate!, style: .date)
+                    Text(asset.creationDate ?? Date.now, style: .date)
                         .font(.system(size: 15, weight: .semibold))
-                    Text(asset.creationDate!, style: .time)
+                    Text(asset.creationDate ?? Date.now, style: .time)
                         .foregroundStyle(.gray)
                         .font(.system(size: 12))
                 }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 네비게이션 이동시 발생하는 문제를 해결하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- Model 관련
    - 다른 `enum`의 인자로 사용하기 위해 `Video` 모델에 `Hashable` 추가
    - 탭과 내비게이션 스플릿 뷰 전환을 위한 `ViewSelection` enum 추가
    - 내비게이션 패스에 스택을 쌓기 위한 `LocalViewSelection`, `AppInfoViewSelection` enum 추가
- 뷰 이동(탭 뷰 / 내비게이션 스플릿 뷰 / 내비게이션 스택 / 내비게이션 패스) 관련
    - `ContentView`에서 뷰 이동을 관리하기 위한 `selectedView` 상태 변수 추가
    - iOS에서 탭 뷰로 이동을 위한 `tag` 추가
    - iPadOS에서 `NavigationSplitView`에 기존 `NavigationLink`를 `Button`으로 변경하여 `selectedView` 값으로 `detail` 뷰를 전환하도록 변경
    - 내비게이션 스택 이동을 위한 `NavigationPath` 추가
    - `NavigationSplitView` 이동시 내비게이션 패스 초기화 코드 추가
    - 내비게이션 패스에 뷰 주입을 위한 `.navigationDestination` 추가
- UI 관련
    - `NavigationLink`를 모두 `Button`으로 변경 
    - `AppInfoView`에서 `NoticeView`로 이동하기 위한 버튼에 `chevron.forward` 모양 추가
- 기타 변경 사항
    - 변수에 넣어 사용하던 뷰를 구조체 인스턴스를 사용하도록 변경
    - `LocalVideoGalleryView`에서 직접 `@StateObject`를 생성하지 않고, 상위 뷰에서 `@ObservedObject`로 주입받아 사용하도록 변경
    - `creationDate`를 강제 언래핑하지 않고 값이 없을 경우 현재 날짜와 시간을 보여주도록 변경
    - 같은 값을 갖지만 로컬 비디오 뷰와 앱 정보 뷰에서 각각 별개의 상태 변수로 따로 관리하던 `updateState`를 `AppVersionManager`에서 하나의 변수로 관리하도록 변경
    - 프로퍼티 순서를 프로퍼티 래퍼에 따라 `@Envrionment`, `@EnvironmentObject`, `@AppStorage`, `@Binding`, `@State`, `@StateObejct`, `@ObservedObject`, 일반 프로퍼티 순으로 변경
    - 불필요한 코드 삭제

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗
- [Apple Developer Documentation/SwiftUI/NavigationPath](https://developer.apple.com/documentation/swiftui/navigationpath)
- [Apple Developer Documentation/SwiftUI/navigationDestination(for:destination:)](https://developer.apple.com/documentation/swiftui/view/navigationdestination(for:destination:))

## Close Issues 🔒 (닫을 Issue)
Close #34.
