### PR TITLE
[Fix] 사파리 뷰에서 보여주는 개발자 정보 및 라이선스 버튼 클릭했을 때 구글로 이동하는 문제

### DIFF
--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -99,8 +99,8 @@ struct AppInfoView: View {
                 }
             }
         }
-        .fullScreenCover(isPresented: $isOpenSafariView, content: {
-            SafariView(url: url)
+        .fullScreenCover(item: $safariViewType, content: { type in
+            SafariView(url: type.url)
         })
         .sheet(isPresented: $isMailSend, content: {
             CustomerServiceMailView()

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -16,10 +16,31 @@ struct AppInfoView: View {
     @State private var isOldVersion = false
     @State private var isSelectAppVersion = false
     @State private var url = URL(string: "https://www.google.com")!
+    @State private var safariViewType: SafariViewType?
     @State private var isMailSend = false
     @State private var isUnavailableMail = false
     @State private var isClearCache: Bool = false
     @State private var cacheCapacity = "0B"
+
+    enum SafariViewType: Identifiable {
+        case developer, license
+
+        var id: String {
+            switch self {
+                case .developer: return "developer"
+                case .license: return "license"
+            }
+        }
+
+        var url: URL {
+            switch self {
+                case .developer:
+                    return URL(string: "https://github.com/taek0622")!
+                case .license:
+                    return URL(string: "https://pippl.notion.site/e318bd246e894b348ece6387e68270de")!
+            }
+        }
+    }
 
     var body: some View {
         List {

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -15,7 +15,6 @@ struct AppInfoView: View {
     @State private var isOpenSafariView = false
     @State private var isOldVersion = false
     @State private var isSelectAppVersion = false
-    @State private var url = URL(string: "https://www.google.com")!
     @State private var safariViewType: SafariViewType?
     @State private var isMailSend = false
     @State private var isUnavailableMail = false
@@ -55,8 +54,7 @@ struct AppInfoView: View {
                 }
             }
             Button(AppText.developerInfo) {
-                url = URL(string: "https://github.com/taek0622")!
-                isOpenSafariView = true
+                safariViewType = .developer
             }
             Button(AppText.customerService) {
                 if !MFMailComposeViewController.canSendMail() {
@@ -66,8 +64,7 @@ struct AppInfoView: View {
                 }
             }
             Button(AppText.license) {
-                url = URL(string: "https://pippl.notion.site/e318bd246e894b348ece6387e68270de")!
-                isOpenSafariView = true
+                safariViewType = .license
             }
             Button {
                 Task {


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 사파리 뷰에서 보여지는 개발자 정보 및 라이선스 버튼을 클릭했을 때, 바로 보여주지 않고 구글을 먼저 보여주는 문제를 해결하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗
- [Apple Developer Documentation/SwiftUI/View/fullScreenCover(item:onDismiss:content:)](https://developer.apple.com/documentation/swiftui/view/fullscreencover(item:ondismiss:content:))

## Close Issues 🔒 (닫을 Issue)
Close #76.
