### PR TITLE
[Refactor] AppInfoView에서 사용되는 3개의 경고 통합

### DIFF
--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -41,6 +41,19 @@ struct AppInfoView: View {
         }
     }
 
+    enum AlertType: Identifiable {
+        case cantSendMail, latestVersion, clearCache
+
+        var id: String {
+            switch self {
+                case .cantSendMail: return "cantSendMail"
+                case .latestVersion: return "latestVersion"
+                case .clearCache: return "clearCache"
+            }
+        }
+
+    }
+
     var body: some View {
         List {
             Button {

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -19,6 +19,8 @@ struct AppInfoView: View {
     @State private var isMailSend = false
     @State private var isUnavailableMail = false
     @State private var isClearCache: Bool = false
+    @State private var isShowingAlert = false
+    @State private var alertType: AlertType = .latestVersion
     @State private var cacheCapacity = "0B"
 
     enum SafariViewType: Identifiable {

--- a/PiPPl/View/AppInfo/AppInfoView.swift
+++ b/PiPPl/View/AppInfo/AppInfoView.swift
@@ -52,6 +52,21 @@ struct AppInfoView: View {
             }
         }
 
+        var title: String {
+            switch self {
+                case .cantSendMail: return AppText.cantSendMailAlertTitle
+                case .latestVersion: return AppText.latestVersionAlertTitle
+                case .clearCache: return AppText.clearAllCache
+            }
+        }
+
+        var message: String {
+            switch self {
+                case .cantSendMail: return AppText.cantSendMailAlertBody
+                case .latestVersion: return AppText.latestVersionAlertBody
+                case .clearCache: return AppText.clearCacheAlertBody
+            }
+        }
     }
 
     var body: some View {


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 3개의 경고창을 통합하여 복잡한 코드 구조를 개선하기 위함

## Key Changes 🔥 (주요 구현/변경 사항)
- 경고창 종류를 구분하기 위한 AlertType enum 추가
- 경고창 종류를 분류하기 위한 `alertType`, 경고창을 보여주기 위한 `isShowingAlert` 변수 추가
- 기존에 사용하던 `isSelectAppVersion`, `isUnavailableMail`, `isClearCache` 변수 삭제
- 최신 버전 앱, 메일 기능 사용 불가, 캐시 초기화 경고창 하나로 통합

## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗

## Close Issues 🔒 (닫을 Issue)
Close #82.
